### PR TITLE
Introduce a new power demand calculation method taking the last  demand into account (Closes: #4)

### DIFF
--- a/components/soyosource_virtual_meter/__init__.py
+++ b/components/soyosource_virtual_meter/__init__.py
@@ -9,6 +9,8 @@ MULTI_CONF = True
 
 CONF_SOYOSOURCE_VIRTUAL_METER_ID = "soyosource_virtual_meter_id"
 CONF_POWER_ID = "power_id"
+CONF_POWER_SENSOR_INACTIVITY_TIMEOUT = "power_sensor_inactivity_timeout"
+CONF_POWER_DEMAND_CALCULATION = "power_demand_calculation"
 CONF_MIN_POWER_DEMAND = "min_power_demand"
 CONF_MAX_POWER_DEMAND = "max_power_demand"
 CONF_BUFFER = "buffer"
@@ -23,6 +25,12 @@ SoyosourceVirtualMeter = soyosource_virtual_meter_ns.class_(
     cg.PollingComponent,
     soyosource_modbus.SoyosourceModbusDevice,
 )
+
+PowerDemandCalculation = soyosource_virtual_meter_ns.enum("PowerDemandCalculation")
+POWER_DEMAND_CALCULATION_OPTIONS = {
+    "DUMB_OEM_BEHAVIOR": PowerDemandCalculation.POWER_DEMAND_CALCULATION_DUMB_OEM_BEHAVIOR,
+    "NEGATIVE_MEASUREMENTS_REQUIRED": PowerDemandCalculation.POWER_DEMAND_CALCULATION_NEGATIVE_MEASUREMENTS_REQUIRED,
+}
 
 
 def validate_min_max(config):
@@ -40,7 +48,13 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SoyosourceVirtualMeter),
+            cv.Optional(
+                CONF_POWER_DEMAND_CALCULATION, default="DUMB_OEM_BEHAVIOR"
+            ): cv.enum(POWER_DEMAND_CALCULATION_OPTIONS, upper=True),
             cv.Required(CONF_POWER_ID): cv.use_id(sensor.Sensor),
+            cv.Optional(
+                CONF_POWER_SENSOR_INACTIVITY_TIMEOUT, default="20s"
+            ): cv.positive_time_period_seconds,
             cv.Optional(CONF_BUFFER, default=DEFAULT_BUFFER): cv.int_range(
                 min=-200, max=200
             ),
@@ -64,7 +78,14 @@ async def to_code(config):
     await soyosource_modbus.register_soyosource_modbus_device(var, config)
 
     sens = await cg.get_variable(config[CONF_POWER_ID])
+
     cg.add(var.set_power_sensor(sens))
     cg.add(var.set_buffer(config[CONF_BUFFER]))
     cg.add(var.set_min_power_demand(config[CONF_MIN_POWER_DEMAND]))
     cg.add(var.set_max_power_demand(config[CONF_MAX_POWER_DEMAND]))
+    cg.add(
+        var.set_power_sensor_inactivity_timeout(
+            config[CONF_POWER_SENSOR_INACTIVITY_TIMEOUT]
+        )
+    )
+    cg.add(var.set_power_demand_calculation(config[CONF_POWER_DEMAND_CALCULATION]))

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -15,7 +15,6 @@ void SoyosourceVirtualMeter::setup() {
     if (std::isnan(state))
       return;
 
-    // this->power_consumption_ = (int16_t) ceilf(state);
     ESP_LOGD(TAG, "calculate_power_demand_ %d %d", (int16_t) ceilf(state), this->last_power_demand_);
     this->power_demand_ = this->calculate_power_demand_((int16_t) ceilf(state), this->last_power_demand_);
     ESP_LOGD(TAG, "New calculated demand: %d / last demand: %d", this->power_demand_, this->last_power_demand_);
@@ -64,7 +63,7 @@ void SoyosourceVirtualMeter::update() {
   ESP_LOGD(TAG, "Setting the limiter to %d watts", power_demand);
   this->send(power_demand);
   this->last_power_demand_ = power_demand;
-  ESP_LOGD(TAG, "New last demand: %d", this->last_power_demand_);
+  ESP_LOGD(TAG, "Updating last demand to: %d", this->last_power_demand_);
 
   this->publish_state_(power_demand_sensor_, power_demand);
 }

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -73,7 +73,7 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_(int16_t consumption, uin
     return this->calculate_power_demand_negative_measurements_(consumption, last_power_demand);
   }
 
-  return this->calculate_power_demand_legacy_(consumption);
+  return this->calculate_power_demand_oem_(consumption);
 }
 
 int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(int16_t consumption,

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -15,7 +15,12 @@ void SoyosourceVirtualMeter::setup() {
     if (std::isnan(state))
       return;
 
-    this->power_consumption_ = (int16_t) ceilf(state);
+    // this->power_consumption_ = (int16_t) ceilf(state);
+    ESP_LOGD(TAG, "calculate_power_demand_ %d %d", (int16_t) ceilf(state), this->last_power_demand_);
+    this->power_demand_ = this->calculate_power_demand_((int16_t) ceilf(state), this->last_power_demand_);
+    ESP_LOGD(TAG, "New calculated demand: %d / last demand: %d", this->power_demand_, this->last_power_demand_);
+
+    this->last_power_demand_received_ = millis();
   });
 }
 
@@ -35,11 +40,20 @@ void SoyosourceVirtualMeter::dump_config() {
 void SoyosourceVirtualMeter::update() {
   uint16_t power_demand = 0;
 
-  if (this->manual_mode_switch_ != nullptr && this->manual_mode_switch_->state &&
-      this->manual_power_demand_number_ != nullptr && this->manual_power_demand_number_->has_state()) {
-    power_demand = (uint16_t) this->manual_power_demand_number_->state;
+  // Manual mode
+  if (this->manual_mode_switch_ != nullptr && this->manual_mode_switch_->state) {
+    if (this->manual_power_demand_number_ != nullptr && this->manual_power_demand_number_->has_state()) {
+      power_demand = (uint16_t) this->manual_power_demand_number_->state;
+    }  // else default = 0
   } else {
-    power_demand = (uint16_t) this->calculate_power_demand_(this->power_consumption_);
+    // Automatic mode
+    if (millis() - this->last_power_demand_received_ < (this->power_sensor_inactivity_timeout_s_ * 1000)) {
+      power_demand = (uint16_t) this->power_demand_;
+    } else {
+      power_demand = 0;
+      ESP_LOGW(TAG, "No power sensor update received since %d seconds. Shutting down for safety reasons.",
+               this->power_sensor_inactivity_timeout_s_);
+    }
   }
 
   // Override power demand on emergency power off
@@ -49,11 +63,46 @@ void SoyosourceVirtualMeter::update() {
 
   ESP_LOGD(TAG, "Setting the limiter to %d watts", power_demand);
   this->send(power_demand);
+  this->last_power_demand_ = power_demand;
+  ESP_LOGD(TAG, "New last demand: %d", this->last_power_demand_);
 
   this->publish_state_(power_demand_sensor_, power_demand);
 }
 
-int16_t SoyosourceVirtualMeter::calculate_power_demand_(int16_t consumption) {
+int16_t SoyosourceVirtualMeter::calculate_power_demand_(int16_t consumption, uint16_t last_power_demand) {
+  if (this->power_demand_calculation_ == POWER_DEMAND_CALCULATION_NEGATIVE_MEASUREMENTS_REQUIRED) {
+    return this->calculate_power_demand_negative_measurements_(consumption, last_power_demand);
+  }
+
+  return this->calculate_power_demand_legacy_(consumption);
+}
+
+int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(int16_t consumption,
+                                                                              uint16_t last_power_demand) {
+  // importing_now   consumption   buffer   last_power_demand   power_demand   return
+  //     1000           1010         10          500               1500         900
+  //      400            410         10          500                900         900
+  //      300            310         10          500                800         800
+  //       10             20         10          500                510         510
+  //        0             10         10          500                500         500
+  //     -200           -190         10          500                300         300
+  //     -500           -490         10          500                  0           0
+  //     -700           -690         10          500               -200           0
+  int16_t importing_now = consumption - this->buffer_;
+  int16_t power_demand = importing_now + last_power_demand;
+
+  if (power_demand >= this->max_power_demand_) {
+    return this->max_power_demand_;
+  }
+
+  if (power_demand > 0) {
+    return power_demand;
+  }
+
+  return 0;
+}
+
+int16_t SoyosourceVirtualMeter::calculate_power_demand_oem_(int16_t consumption) {
   // 5000 > 2000 + 10: 2000
   // 2011 > 2000 + 10: 2000
   // 2010 > 2000 + 10: continue

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -9,6 +9,11 @@
 namespace esphome {
 namespace soyosource_virtual_meter {
 
+enum PowerDemandCalculation {
+  POWER_DEMAND_CALCULATION_DUMB_OEM_BEHAVIOR,
+  POWER_DEMAND_CALCULATION_NEGATIVE_MEASUREMENTS_REQUIRED,
+};
+
 class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus::SoyosourceModbusDevice {
  public:
   void set_power_sensor(sensor::Sensor *power_sensor) { power_sensor_ = power_sensor; }
@@ -16,6 +21,12 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   void set_buffer(int16_t buffer) { this->buffer_ = buffer; }
   void set_min_power_demand(int16_t min_power_demand) { this->min_power_demand_ = min_power_demand; }
   void set_max_power_demand(int16_t max_power_demand) { this->max_power_demand_ = max_power_demand; }
+  void set_power_sensor_inactivity_timeout(uint16_t power_sensor_inactivity_timeout_s) {
+    this->power_sensor_inactivity_timeout_s_ = power_sensor_inactivity_timeout_s;
+  }
+  void set_power_demand_calculation(PowerDemandCalculation power_demand_calculation) {
+    this->power_demand_calculation_ = power_demand_calculation;
+  }
 
   void set_manual_power_demand_number(number::Number *manual_power_demand_number) {
     manual_power_demand_number_ = manual_power_demand_number;
@@ -36,6 +47,8 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
+  PowerDemandCalculation power_demand_calculation_{DUMB_OEM_BEHAVIOR};
+
   sensor::Sensor *power_sensor_;
   sensor::Sensor *power_demand_sensor_;
 
@@ -47,10 +60,16 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   int16_t buffer_;
   int16_t min_power_demand_;
   int16_t max_power_demand_;
-  int16_t power_consumption_;
+  int16_t power_demand_;
+  uint16_t power_sensor_inactivity_timeout_s_;
+
+  uint32_t last_power_demand_received_{0};
+  uint16_t last_power_demand_{0};
 
   void publish_state_(sensor::Sensor *sensor, float value);
-  int16_t calculate_power_demand_(int16_t consumption);
+  int16_t calculate_power_demand_(int16_t consumption, uint16_t last_power_demand);
+  int16_t calculate_power_demand_negative_measurements_(int16_t consumption, uint16_t last_power_demand);
+  int16_t calculate_power_demand_oem_(int16_t consumption);
 };
 
 }  // namespace soyosource_virtual_meter

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -47,7 +47,7 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
-  PowerDemandCalculation power_demand_calculation_{DUMB_OEM_BEHAVIOR};
+  PowerDemandCalculation power_demand_calculation_{POWER_DEMAND_CALCULATION_DUMB_OEM_BEHAVIOR};
 
   sensor::Sensor *power_sensor_;
   sensor::Sensor *power_demand_sensor_;

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -39,6 +39,8 @@ soyosource_inverter:
 soyosource_virtual_meter:
   # the state of this sensor (instantaneous power in watt) is used as source
   power_id: powermeter
+  power_sensor_inactivity_timeout: 20s
+  power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
   min_power_demand: 0
   max_power_demand: 900
   # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)
@@ -81,6 +83,8 @@ sensor:
     accuracy_decimals: 2
     unit_of_measurement: W
     device_class: power
+    filters:
+      - throttle_average: 15s
 
 text_sensor:
   - platform: soyosource_inverter
@@ -107,3 +111,6 @@ switch:
 #    id: powermeter
 #    name: "${name} smartmeter instantaneous power"
 #    entity_id: sensor.firstfloor_smartmeter_instantaneous_power
+#    filters:
+#      - throttle_average: 15s
+#      - filter_out: nan

--- a/esp32-multiple-uarts-example.yaml
+++ b/esp32-multiple-uarts-example.yaml
@@ -59,8 +59,11 @@ soyosource_virtual_meter:
   - id: virtualmeter0
     soyosource_modbus_id: modbus0
     update_interval: 3s
+
     # the state of this sensor (instantaneous power in watt) is used as source
     power_id: powermeter0
+    power_sensor_inactivity_timeout: 20s
+    power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)
@@ -71,6 +74,8 @@ soyosource_virtual_meter:
     update_interval: 3s
     # the state of this sensor (instantaneous power in watt) is used as source
     power_id: powermeter1
+    power_sensor_inactivity_timeout: 20s
+    power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)
@@ -139,6 +144,9 @@ sensor:
     accuracy_decimals: 2
     unit_of_measurement: W
     device_class: power
+    filters:
+      - throttle_average: 15s
+
   - id: powermeter1
     internal: true
     platform: mqtt_subscribe
@@ -147,6 +155,8 @@ sensor:
     accuracy_decimals: 2
     unit_of_measurement: W
     device_class: power
+    filters:
+      - throttle_average: 15s
 
 #  # import smartmeter reading from homeassistant f.e.
 #  # requires the "api" component see above

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -40,6 +40,8 @@ soyosource_virtual_meter:
   update_interval: 3s
   # the state of this sensor (instantaneous power in watt) is used as source
   power_id: powermeter
+  power_sensor_inactivity_timeout: 20s
+  power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
   min_power_demand: 0
   max_power_demand: 900
   # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)
@@ -81,6 +83,8 @@ sensor:
     accuracy_decimals: 2
     unit_of_measurement: W
     device_class: power
+    filters:
+      - throttle_average: 15s
 
 #  # import smartmeter reading from homeassistant
 #  # requires the "api" component see above
@@ -88,6 +92,10 @@ sensor:
 #    id: powermeter
 #    name: "${name} smartmeter instantaneous power"
 #    entity_id: sensor.firstfloor_smartmeter_instantaneous_power
+#    filters:
+#      - throttle_average: 15s
+#      - filter_out: nan
+
 
 text_sensor:
   - platform: soyosource_inverter


### PR DESCRIPTION
This new method requires a smartmeter supporting negative measurements in case of exporting power to the grid.

If your `instantaneous power consumption` sensor provides always positive measurements you cannot use this new method.

Closes: #16 #4