### PR TITLE
Consider power_demand_divider when computing the power_demand

### DIFF
--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -104,7 +104,7 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
   int16_t importing_now = consumption - this->buffer_;
   int16_t power_demand = importing_now + last_power_demand;
 
-  if (power_demand >= this->max_power_demand_ * float(this->power_demand_divider_)) { 
+  if (power_demand >= this->max_power_demand_ * float(this->power_demand_divider_)) {
     return this->max_power_demand_ * float(this->power_demand_divider_);
   }
 

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -38,7 +38,7 @@ void SoyosourceVirtualMeter::update() {
   if (this->manual_mode_switch_ != nullptr && this->manual_mode_switch_->state) {
     operation_mode = "Manual";
     if (this->manual_power_demand_number_ != nullptr && this->manual_power_demand_number_->has_state()) {
-      power_demand = (uint16_t) this->manual_power_demand_number_->state;
+      power_demand = (uint16_t) this->manual_power_demand_number_->state * float(this->power_demand_divider_);
     }  // else default = 0
   } else {
     // Automatic mode

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -104,8 +104,8 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
   int16_t importing_now = consumption - this->buffer_;
   int16_t power_demand = importing_now + last_power_demand;
 
-  if (power_demand >= this->max_power_demand_) {
-    return this->max_power_demand_;
+  if (power_demand >= this->max_power_demand_ * float(this->power_demand_divider_)) { 
+    return this->max_power_demand_ * float(this->power_demand_divider_);
   }
 
   if (power_demand > this->min_power_demand_) {


### PR DESCRIPTION
Easy fix for https://github.com/syssi/esphome-soyosource-gtn-virtual-meter/issues/86