### PR TITLE
Overshoot compensation

### DIFF
--- a/components/soyosource_virtual_meter/__init__.py
+++ b/components/soyosource_virtual_meter/__init__.py
@@ -91,8 +91,12 @@ CONFIG_SCHEMA = cv.All(
             ): cv.int_range(min=1, max=5400),
             cv.Optional(CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND, default=True): cv.boolean,
             cv.Optional(
-                CONF_MAX_POWER_SENSOR_LATENCY_MS, default=DEFAULT_MAX_POWER_SENSOR_LATENCY_MS
-            ): cv.int_range(min=DEFAULT_MIN_MAX_POWER_SENSOR_LATENCY_MS, max=DEFAULT_MAX_MAX_POWER_SENSOR_LATENCY_MS),
+                CONF_MAX_POWER_SENSOR_LATENCY_MS,
+                default=DEFAULT_MAX_POWER_SENSOR_LATENCY_MS,
+            ): cv.int_range(
+                min=DEFAULT_MIN_MAX_POWER_SENSOR_LATENCY_MS,
+                max=DEFAULT_MAX_MAX_POWER_SENSOR_LATENCY_MS,
+            ),
         }
     )
     .extend(soyosource_modbus.soyosource_modbus_device_schema(0x24))

--- a/components/soyosource_virtual_meter/__init__.py
+++ b/components/soyosource_virtual_meter/__init__.py
@@ -19,6 +19,7 @@ CONF_BUFFER = "buffer"
 CONF_POWER_DEMAND_DIVIDER = "power_demand_divider"
 CONF_OPERATION_STATUS_ID = "operation_status_id"
 CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND = "zero_output_on_min_power_demand"
+CONF_MAX_POWER_SENSOR_LATENCY_MS = "max_power_sensor_latency_ms"
 
 DEFAULT_MIN_BUFFER = -200
 DEFAULT_MAX_BUFFER = 200
@@ -30,6 +31,10 @@ DEFAULT_MAX_POWER_DEMAND = 900
 DEFAULT_POWER_DEMAND_DIVIDER = 1
 DEFAULT_MIN_POWER_DEMAND_DIVIDER = 1
 DEFAULT_MAX_POWER_DEMAND_DIVIDER = 6
+
+DEFAULT_MAX_POWER_SENSOR_LATENCY_MS = 4000
+DEFAULT_MIN_MAX_POWER_SENSOR_LATENCY_MS = 0
+DEFAULT_MAX_MAX_POWER_SENSOR_LATENCY_MS = 30000
 
 soyosource_virtual_meter_ns = cg.esphome_ns.namespace("soyosource_virtual_meter")
 SoyosourceVirtualMeter = soyosource_virtual_meter_ns.class_(
@@ -85,6 +90,9 @@ CONFIG_SCHEMA = cv.All(
                 CONF_MAX_POWER_DEMAND, default=DEFAULT_MAX_POWER_DEMAND
             ): cv.int_range(min=1, max=5400),
             cv.Optional(CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND, default=True): cv.boolean,
+            cv.Optional(
+                CONF_MAX_POWER_SENSOR_LATENCY_MS, default=DEFAULT_MAX_POWER_SENSOR_LATENCY_MS
+            ): cv.int_range(min=DEFAULT_MIN_MAX_POWER_SENSOR_LATENCY_MS, max=DEFAULT_MAX_MAX_POWER_SENSOR_LATENCY_MS),
         }
     )
     .extend(soyosource_modbus.soyosource_modbus_device_schema(0x24))
@@ -116,6 +124,7 @@ async def to_code(config):
         )
     )
     cg.add(var.set_power_demand_calculation(config[CONF_POWER_DEMAND_CALCULATION]))
+    cg.add(var.set_power_demand_delta_timeout(config[CONF_MAX_POWER_SENSOR_LATENCY_MS]))
 
     if CONF_OPERATION_STATUS_ID in config:
         operation_status_sensor = await cg.get_variable(

--- a/components/soyosource_virtual_meter/__init__.py
+++ b/components/soyosource_virtual_meter/__init__.py
@@ -20,6 +20,7 @@ CONF_POWER_DEMAND_DIVIDER = "power_demand_divider"
 CONF_OPERATION_STATUS_ID = "operation_status_id"
 CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND = "zero_output_on_min_power_demand"
 CONF_MAX_POWER_SENSOR_LATENCY_MS = "max_power_sensor_latency_ms"
+CONF_POWER_SENSOR_PID_KP = "power_sensor_pid_Kp"
 
 DEFAULT_MIN_BUFFER = -200
 DEFAULT_MAX_BUFFER = 200
@@ -35,6 +36,8 @@ DEFAULT_MAX_POWER_DEMAND_DIVIDER = 6
 DEFAULT_MAX_POWER_SENSOR_LATENCY_MS = 4000
 DEFAULT_MIN_MAX_POWER_SENSOR_LATENCY_MS = 0
 DEFAULT_MAX_MAX_POWER_SENSOR_LATENCY_MS = 30000
+
+DEFAULT_CONF_POWER_SENSOR_PID_KP = 0.65
 
 soyosource_virtual_meter_ns = cg.esphome_ns.namespace("soyosource_virtual_meter")
 SoyosourceVirtualMeter = soyosource_virtual_meter_ns.class_(
@@ -97,6 +100,13 @@ CONFIG_SCHEMA = cv.All(
                 min=DEFAULT_MIN_MAX_POWER_SENSOR_LATENCY_MS,
                 max=DEFAULT_MAX_MAX_POWER_SENSOR_LATENCY_MS,
             ),
+            cv.Optional(
+                CONF_POWER_SENSOR_PID_KP,
+                default=DEFAULT_CONF_POWER_SENSOR_PID_KP,
+            ): cv.float_range(
+                min=0.01,
+                max=1.0,
+            ),
         }
     )
     .extend(soyosource_modbus.soyosource_modbus_device_schema(0x24))
@@ -129,6 +139,7 @@ async def to_code(config):
     )
     cg.add(var.set_power_demand_calculation(config[CONF_POWER_DEMAND_CALCULATION]))
     cg.add(var.set_power_demand_delta_timeout(config[CONF_MAX_POWER_SENSOR_LATENCY_MS]))
+    cg.add(var.set_power_demand_delta_pid_Kp(config[CONF_POWER_SENSOR_PID_KP]))
 
     if CONF_OPERATION_STATUS_ID in config:
         operation_status_sensor = await cg.get_variable(

--- a/components/soyosource_virtual_meter/__init__.py
+++ b/components/soyosource_virtual_meter/__init__.py
@@ -20,7 +20,7 @@ CONF_POWER_DEMAND_DIVIDER = "power_demand_divider"
 CONF_OPERATION_STATUS_ID = "operation_status_id"
 CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND = "zero_output_on_min_power_demand"
 CONF_MAX_POWER_SENSOR_LATENCY_MS = "max_power_sensor_latency_ms"
-CONF_POWER_SENSOR_PID_KP = "power_sensor_pid_Kp"
+CONF_POWER_SENSOR_PID_KP = "power_sensor_pid_kp"
 
 DEFAULT_MIN_BUFFER = -200
 DEFAULT_MAX_BUFFER = 200
@@ -139,7 +139,7 @@ async def to_code(config):
     )
     cg.add(var.set_power_demand_calculation(config[CONF_POWER_DEMAND_CALCULATION]))
     cg.add(var.set_power_demand_delta_timeout(config[CONF_MAX_POWER_SENSOR_LATENCY_MS]))
-    cg.add(var.set_power_demand_delta_pid_Kp(config[CONF_POWER_SENSOR_PID_KP]))
+    cg.add(var.set_power_demand_delta_pid_kp(config[CONF_POWER_SENSOR_PID_KP]))
 
     if CONF_OPERATION_STATUS_ID in config:
         operation_status_sensor = await cg.get_variable(

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -20,6 +20,11 @@ void SoyosourceVirtualMeter::setup() {
              this->last_power_demand_);
 
     this->last_power_demand_received_ = millis();
+
+    //if update intervall is set to never, trigger the update() method from here
+    if (this->get_update_interval() == -1) {
+      this->update();
+    }
   });
 }
 

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -149,8 +149,7 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
 
   if (power_demand >= this->max_power_demand_) {
     power_demand = this->max_power_demand_;
-  }
-  else if (power_demand < this->min_power_demand_) {
+  } else if (power_demand < this->min_power_demand_) {
     power_demand = (this->zero_output_on_min_power_demand_) ? 0 : this->min_power_demand_;
   }
 

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -22,7 +22,7 @@ void SoyosourceVirtualMeter::setup() {
     this->last_power_demand_received_ = millis();
 
     //if update intervall is set to never, trigger the update() method from here
-    if (this->get_update_interval() == -1) {
+    if (this->get_update_interval() == SCHEDULER_DONT_RUN) {
       this->update();
     }
   });

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -113,7 +113,7 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
   int16_t importing_now = consumption - this->buffer_;
   int16_t power_demand;
 
-  if (importing_now == 0 || last_consumption_ == importing_now) {
+  if (importing_now == 0 || (this->last_consumption_ == importing_now && millis() <= this->power_demand_delta_timestamp_ + this->power_demand_delta_timeout_)) {
     power_demand = last_power_demand;
 
     ESP_LOGD(TAG, "'%s': keeping old demand (importing now is 0 or no new sensor reading available)",

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -216,7 +216,7 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_oem_(int16_t consumption)
   //  100 >= 100: (abs(100 - 10) + (100 - 10)) / 2 = 90
   //   90 >= 100: continue
   if (consumption >= this->min_power_demand_)
-    return (int16_t)((std::abs(consumption - this->buffer_) + (consumption - this->buffer_)) / 2);
+    return (int16_t) ((std::abs(consumption - this->buffer_) + (consumption - this->buffer_)) / 2);
 
   // 90: 0
   return 0;

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -21,7 +21,7 @@ void SoyosourceVirtualMeter::setup() {
 
     this->last_power_demand_received_ = millis();
 
-    //if update intervall is set to never, trigger the update() method from here
+    // if update intervall is set to never, trigger the update() method from here
     if (this->get_update_interval() == SCHEDULER_DONT_RUN) {
       this->update();
     }
@@ -114,38 +114,36 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
   int16_t power_demand;
 
   if (importing_now == 0) {
-    //let's just keep it 0 then :D
+    // let's just keep it 0 then :D
     power_demand = last_power_demand;
     this->power_demand_delta_ = 0;
 
-  }
-  else if (this->power_demand_delta_timeout_ > 0) {
-    int16_t consumption_diff = this->last_consumption_ > importing_now ? this->last_consumption_ - importing_now : importing_now - this->last_consumption_;
-    float magic_demand_delta_ = abs(this->power_demand_delta_) * this->power_demand_delta_magic_constant_;
+  } else if (this->power_demand_delta_timeout_ > 0) {
+    int16_t consumption_diff = this->last_consumption_ > importing_now ? this->last_consumption_ - importing_now
+                                                                       : importing_now - this->last_consumption_;
+    float magic_demand_delta = abs(this->power_demand_delta_) * this->power_demand_delta_magic_constant_;
     this->last_consumption_ = importing_now;
 
-    ESP_LOGD(TAG, "'%s': consumption_diff: %d, power_demand_delta_: %d, magic_demand_delta_: %f", this->get_modbus_name(),
-                   consumption_diff, this->power_demand_delta_, magic_demand_delta_);
+    ESP_LOGD(TAG, "'%s': consumption_diff: %d, power_demand_delta_: %d, magic_demand_delta_: %f",
+             this->get_modbus_name(), consumption_diff, this->power_demand_delta_, magic_demand_delta);
 
-    if (this->power_demand_delta_ > 0 && (consumption_diff > magic_demand_delta_
-        || millis() > this->power_demand_delta_timestamp_ + this->power_demand_delta_timeout_)) {
-
+    if (this->power_demand_delta_ > 0 &&
+        (consumption_diff > magic_demand_delta ||
+         millis() > this->power_demand_delta_timestamp_ + this->power_demand_delta_timeout_)) {
       this->power_demand_delta_ = 0;
       ESP_LOGD(TAG, "'%s': power_demand_delta_ reset to 0 due to %s", this->get_modbus_name(),
-                    consumption_diff > magic_demand_delta_ ? "consumption_diff" : "timeout");
+               consumption_diff > magic_demand_delta ? "consumption_diff" : "timeout");
     }
 
     power_demand = importing_now + last_power_demand - this->power_demand_delta_;
 
-    if (this->power_demand_delta_ > 0 && ((importing_now > 0 && power_demand < last_power_demand)
-        || (importing_now < 0 && power_demand > last_power_demand))) {
-
+    if (this->power_demand_delta_ > 0 && ((importing_now > 0 && power_demand < last_power_demand) ||
+                                          (importing_now < 0 && power_demand > last_power_demand))) {
       power_demand = last_power_demand;
-      ESP_LOGD(TAG, "'%s': Oscillation prevention, keeping previous demand: %d; consumption: %d", this->get_modbus_name(),
-                    last_power_demand, importing_now);
+      ESP_LOGD(TAG, "'%s': Oscillation prevention, keeping previous demand: %d; consumption: %d",
+               this->get_modbus_name(), last_power_demand, importing_now);
     }
-  }
-  else {
+  } else {
     power_demand = importing_now + last_power_demand;
   }
 

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -123,7 +123,7 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
   } else if (this->power_demand_delta_timeout_ > 0) {
     int16_t consumption_diff = this->last_consumption_ > importing_now ? this->last_consumption_ - importing_now
                                                                        : importing_now - this->last_consumption_;
-    float demand_delta_pid = abs(this->power_demand_delta_) * this->power_demand_delta_pid_Kp_;
+    float demand_delta_pid = abs(this->power_demand_delta_) * this->power_demand_delta_pid_kp_;
     this->last_consumption_ = importing_now;
 
     ESP_LOGD(TAG, "'%s': consumption_diff: %d, power_demand_delta_: %d, demand_delta_pid: %f", this->get_modbus_name(),

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -21,7 +21,7 @@ void SoyosourceVirtualMeter::setup() {
 
     this->last_power_demand_received_ = millis();
 
-    // if update intervall is set to never, trigger the update() method from here
+    // If the update_interval is set to never, call the update() method on every power sensor update
     if (this->get_update_interval() == SCHEDULER_DONT_RUN) {
       this->update();
     }

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -134,6 +134,12 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
     }
 
     power_demand = importing_now + last_power_demand - this->power_demand_delta_;
+
+    if ((importing_now > 0 && power_demand < last_power_demand) || (importing_now < 0 && power_demand > last_power_demand)) {
+      ESP_LOGD(TAG, "'%s': Oscillation prevention, keeping previous demand: %d; consumption: %d", this->get_modbus_name(),
+                    last_power_demand, importing_now);
+      power_demand = last_power_demand;
+    }
   }
 
   this->last_consumption_ = importing_now;

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -47,7 +47,9 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   void set_power_demand_divider_number(number::Number *power_demand_divider_number) {
     power_demand_divider_number_ = power_demand_divider_number;
   }
-  void set_power_demand_delta_timeout(uint16_t power_demand_delta_timeout) { this->power_demand_delta_timeout_ = power_demand_delta_timeout; }
+  void set_power_demand_delta_timeout(uint16_t power_demand_delta_timeout) {
+    this->power_demand_delta_timeout_ = power_demand_delta_timeout;
+  }
 
   void set_manual_mode_switch(switch_::Switch *manual_mode_switch) { manual_mode_switch_ = manual_mode_switch; }
   void set_emergency_power_off_switch(switch_::Switch *emergency_power_off_switch) {
@@ -99,7 +101,7 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   int16_t power_demand_delta_{0};
   uint32_t power_demand_delta_timestamp_{0};
 
-  float power_demand_delta_magic_constant_{0.8};    //make it configurable?
+  float power_demand_delta_magic_constant_{0.8};  // make it configurable?
   uint16_t power_demand_delta_timeout_{0};
 
   void publish_state_(sensor::Sensor *sensor, float value);

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -51,6 +51,10 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
     this->power_demand_delta_timeout_ = power_demand_delta_timeout;
   }
 
+  void set_power_demand_delta_pid_Kp(float power_demand_delta_pid_Kp) {
+    this->power_demand_delta_pid_Kp_ = power_demand_delta_pid_Kp;
+  }
+
   void set_manual_mode_switch(switch_::Switch *manual_mode_switch) { manual_mode_switch_ = manual_mode_switch; }
   void set_emergency_power_off_switch(switch_::Switch *emergency_power_off_switch) {
     emergency_power_off_switch_ = emergency_power_off_switch;
@@ -101,7 +105,7 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   int16_t power_demand_delta_{0};
   uint32_t power_demand_delta_timestamp_{0};
 
-  float power_demand_delta_magic_constant_{0.65};  // make it configurable?
+  float power_demand_delta_pid_Kp_{0.65};
   uint16_t power_demand_delta_timeout_{0};
 
   void publish_state_(sensor::Sensor *sensor, float value);

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -94,6 +94,13 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   uint32_t last_power_demand_received_{0};
   uint16_t last_power_demand_{0};
 
+  int32_t last_consumption_{0};
+  int16_t power_demand_delta_{0};
+  uint32_t power_demand_delta_timestamp_{0};
+
+  float power_demand_delta_magic_constant_{0.8};    //make it configurable?
+  uint16_t power_demand_delta_timeout_{4000};       //make it configurable?
+
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
   bool inactivity_timeout_();

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -51,8 +51,8 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
     this->power_demand_delta_timeout_ = power_demand_delta_timeout;
   }
 
-  void set_power_demand_delta_pid_Kp(float power_demand_delta_pid_Kp) {
-    this->power_demand_delta_pid_Kp_ = power_demand_delta_pid_Kp;
+  void set_power_demand_delta_pid_kp(float power_demand_delta_pid_kp) {
+    this->power_demand_delta_pid_kp_ = power_demand_delta_pid_kp;
   }
 
   void set_manual_mode_switch(switch_::Switch *manual_mode_switch) { manual_mode_switch_ = manual_mode_switch; }
@@ -105,7 +105,7 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   int16_t power_demand_delta_{0};
   uint32_t power_demand_delta_timestamp_{0};
 
-  float power_demand_delta_pid_Kp_{0.65};
+  float power_demand_delta_pid_kp_{0.65};
   uint16_t power_demand_delta_timeout_{0};
 
   void publish_state_(sensor::Sensor *sensor, float value);

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -47,6 +47,7 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   void set_power_demand_divider_number(number::Number *power_demand_divider_number) {
     power_demand_divider_number_ = power_demand_divider_number;
   }
+  void set_power_demand_delta_timeout(uint16_t power_demand_delta_timeout) { this->power_demand_delta_timeout_ = power_demand_delta_timeout; }
 
   void set_manual_mode_switch(switch_::Switch *manual_mode_switch) { manual_mode_switch_ = manual_mode_switch; }
   void set_emergency_power_off_switch(switch_::Switch *emergency_power_off_switch) {
@@ -99,7 +100,7 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   uint32_t power_demand_delta_timestamp_{0};
 
   float power_demand_delta_magic_constant_{0.8};    //make it configurable?
-  uint16_t power_demand_delta_timeout_{4000};       //make it configurable?
+  uint16_t power_demand_delta_timeout_{0};
 
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);


### PR DESCRIPTION
My take on https://github.com/syssi/esphome-soyosource-gtn-virtual-meter/issues/73 😄 

![powerc2](https://user-images.githubusercontent.com/6198352/225608086-70e10051-1aa4-405d-8475-3ed1ed9a4c7b.png)

This graph shows the overshoot compensation in action with an update intervall of 0.5s. The powermeter provides new power readings a bit random between 0.7s and 2s (mostly 1s). The graph is for exactly that powermeter sensor.

It's not perfectly flat because the other inverter makes it spiky already and the time resolution of the graph is pretty hight. 😛 

With slow update interval of 3s (and no other inverter): https://github.com/syssi/esphome-soyosource-gtn-virtual-meter/issues/73#issuecomment-1465274313
Without compensation: https://github.com/syssi/esphome-soyosource-gtn-virtual-meter/issues/73#issuecomment-1460813033


I've added a new setting: max_power_sensor_latency_ms, which is 4000 (4s) by default.
That value also works for your defaults with 3s update_intervall. For higher update_intervalls this feature basically disables itself because of this value.
You can also set it to 0 to make sure it's disabled.

I did not add examples yet, because I don't know if you like it, yet. 😉 
Please review & test.
