### PR TITLE
Introduce new setting zero_output_on_min_power_demand

### DIFF
--- a/components/soyosource_virtual_meter/__init__.py
+++ b/components/soyosource_virtual_meter/__init__.py
@@ -16,6 +16,7 @@ CONF_MAX_POWER_DEMAND = "max_power_demand"
 CONF_BUFFER = "buffer"
 CONF_POWER_DEMAND_DIVIDER = "power_demand_divider"
 CONF_OPERATION_STATUS_ID = "operation_status_id"
+CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND = "zero_output_on_min_power_demand"
 
 DEFAULT_MIN_BUFFER = -200
 DEFAULT_MAX_BUFFER = 200
@@ -81,6 +82,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_MAX_POWER_DEMAND, default=DEFAULT_MAX_POWER_DEMAND
             ): cv.int_range(min=1, max=5400),
+            cv.Optional(CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND, default=True): cv.boolean,
         }
     )
     .extend(soyosource_modbus.soyosource_modbus_device_schema(0x24))
@@ -100,6 +102,11 @@ async def to_code(config):
     cg.add(var.set_buffer(config[CONF_BUFFER]))
     cg.add(var.set_min_power_demand(config[CONF_MIN_POWER_DEMAND]))
     cg.add(var.set_max_power_demand(config[CONF_MAX_POWER_DEMAND]))
+    cg.add(
+        var.set_zero_output_on_min_power_demand(
+            config[CONF_ZERO_OUTPUT_ON_MIN_POWER_DEMAND]
+        )
+    )
     cg.add(var.set_power_demand_divider(config[CONF_POWER_DEMAND_DIVIDER]))
     cg.add(
         var.set_power_sensor_inactivity_timeout(

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -113,7 +113,7 @@ int16_t SoyosourceVirtualMeter::calculate_power_demand_negative_measurements_(in
   }
 
   if (power_demand < this->min_power_demand_) {
-    return this->min_power_demand_;
+    return (this->zero_output_on_min_power_demand_) ? 0 : this->min_power_demand_;
   }
 
   return power_demand;

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -26,6 +26,9 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   void set_buffer(int16_t buffer) { this->buffer_ = buffer; }
   void set_min_power_demand(int16_t min_power_demand) { this->min_power_demand_ = min_power_demand; }
   void set_max_power_demand(int16_t max_power_demand) { this->max_power_demand_ = max_power_demand; }
+  void set_zero_output_on_min_power_demand(bool zero_output_on_min_power_demand) {
+    this->zero_output_on_min_power_demand_ = zero_output_on_min_power_demand;
+  }
   void set_power_demand_divider(uint8_t power_demand_divider) { this->power_demand_divider_ = power_demand_divider; }
   void set_power_sensor_inactivity_timeout(uint16_t power_sensor_inactivity_timeout_s) {
     this->power_sensor_inactivity_timeout_s_ = power_sensor_inactivity_timeout_s;
@@ -80,6 +83,7 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
 
   text_sensor::TextSensor *operation_mode_text_sensor_;
 
+  bool zero_output_on_min_power_demand_{true};
   int16_t buffer_;
   int16_t min_power_demand_;
   int16_t max_power_demand_;

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -66,6 +66,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # Split/distribute the power demand if you have multiple inverters attached to the same RS485 bus
     power_demand_divider: 1
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)

--- a/esp32-limiter-example.yaml
+++ b/esp32-limiter-example.yaml
@@ -66,6 +66,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # Split/distribute the power demand if you have multiple inverters attached to the same RS485 bus
     power_demand_divider: 1
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)

--- a/esp32-multiple-uarts-example.yaml
+++ b/esp32-multiple-uarts-example.yaml
@@ -82,6 +82,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)
     # A negative buffer value (-10) exports power to the grid (demand + 10 watts)
     buffer: 10
@@ -98,6 +99,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)
     # A negative buffer value (-10) exports power to the grid (demand + 10 watts)
     buffer: 10

--- a/esp8266-display-display-version-limiter-example.yaml
+++ b/esp8266-display-display-version-limiter-example.yaml
@@ -67,6 +67,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # Split/distribute the power demand if you have multiple inverters attached to the same RS485 bus
     power_demand_divider: 1
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)

--- a/esp8266-display-wifi-version-limiter-example.yaml
+++ b/esp8266-display-wifi-version-limiter-example.yaml
@@ -67,6 +67,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # Split/distribute the power demand if you have multiple inverters attached to the same RS485 bus
     power_demand_divider: 1
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -66,6 +66,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # Split/distribute the power demand if you have multiple inverters attached to the same RS485 bus
     power_demand_divider: 1
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)

--- a/esp8266-limiter-example.yaml
+++ b/esp8266-limiter-example.yaml
@@ -66,6 +66,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # Split/distribute the power demand if you have multiple inverters attached to the same RS485 bus
     power_demand_divider: 1
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)

--- a/esp8266-wifi-dongle-limiter-example.yaml
+++ b/esp8266-wifi-dongle-limiter-example.yaml
@@ -70,6 +70,7 @@ soyosource_virtual_meter:
     power_demand_calculation: NEGATIVE_MEASUREMENTS_REQUIRED
     min_power_demand: 0
     max_power_demand: 900
+    zero_output_on_min_power_demand: true
     # Split/distribute the power demand if you have multiple inverters attached to the same RS485 bus
     power_demand_divider: 1
     # A positive buffer value (10) tries to avoid exporting power to the grid (demand - 10 watts)


### PR DESCRIPTION
… to avoid breaking change

FYI @kevin300

I remembered the idea behind `power_demand < min_power_demand returns 0` again. There are people around which don't want to drive the inverter in inefficient ranges. For example the power demand must be greater then 150W, so the inverter kicks in. If the power demand is less then 150W it should stay off.

The PR brings back the initial behaviour and allows a lower bound using `min_power_demand` + `zero_output_on_min_power_demand: false` too now.