### PR TITLE
Fix bitmask sensors: remove state_class, set device_class=None, add diagnostic entity_category

### DIFF
--- a/components/soyosource_display/sensor.py
+++ b/components/soyosource_display/sensor.py
@@ -70,8 +70,7 @@ CONFIG_SCHEMA = SOYOSOURCE_DISPLAY_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon=ICON_ERROR_BITMASK,
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            device_class=None,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_OPERATION_MODE_ID): sensor.sensor_schema(


### PR DESCRIPTION
## Changes

Bitmask sensors represent raw status/flag values, not physical measurements. This fix aligns them with ESPHome best practices:

- Remove `state_class` (bitmasks are not measurements)
- Set `device_class=None` (no meaningful device class applies)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC`