### PR TITLE
Fix bitmask sensor

### DIFF
--- a/components/soyosource_display/sensor.py
+++ b/components/soyosource_display/sensor.py
@@ -70,7 +70,7 @@ CONFIG_SCHEMA = SOYOSOURCE_DISPLAY_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon=ICON_ERROR_BITMASK,
             accuracy_decimals=0,
-            device_class=None,
+            device_class=DEVICE_CLASS_EMPTY,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_OPERATION_MODE_ID): sensor.sensor_schema(


### PR DESCRIPTION
`device_class=None` is not a valid value in ESPHome's sensor schema and causes a validation error:

```
string value is None.
Error: Process completed with exit code 2.
```

Replace with `DEVICE_CLASS_EMPTY` which is the correct constant for sensors without a device class.