### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/soyosource_virtual_meter/sensor.py
+++ b/components/soyosource_virtual_meter/sensor.py
@@ -14,6 +14,7 @@ from . import (
 )
 
 DEPENDENCIES = ["soyosource_virtual_meter"]
+CODEOWNERS = ["@syssi"]
 
 CONF_POWER_DEMAND = "power_demand"
 


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `soyosource_virtual_meter/sensor.py` for consistency with other ESPHome components.