### PR TITLE
Fix text_sensor_schema positional arg

### DIFF
--- a/components/soyosource_display/text_sensor.py
+++ b/components/soyosource_display/text_sensor.py
@@ -27,16 +27,13 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = SOYOSOURCE_DISPLAY_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_ERRORS,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_OPERATION_MODE,
         ),
         cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_OPERATION_STATUS,
         ),
     }

--- a/components/soyosource_inverter/text_sensor.py
+++ b/components/soyosource_inverter/text_sensor.py
@@ -19,7 +19,7 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = SOYOSOURCE_INVERTER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_OPERATION_STATUS
+            icon=ICON_OPERATION_STATUS
         ),
     }
 )

--- a/components/soyosource_virtual_meter/text_sensor.py
+++ b/components/soyosource_virtual_meter/text_sensor.py
@@ -22,7 +22,6 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = SOYOSOURCE_VIRTUAL_METER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_OPERATION_MODE,
         ),
     }


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls in `soyosource_display`, `soyosource_inverter`, and `soyosource_virtual_meter` components (T1)

Follows the pattern established in `esphome-tianpower-bms`.