### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -91,25 +91,25 @@ binary_sensor:
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
 
 number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${name} buffer"
+      name: "buffer"
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${name} manual power demand"
+      name: "manual power demand"
       max_value: 900
     max_power_demand:
-      name: "${name} max power demand"
+      name: "max power demand"
       initial_value: 600
       max_value: 900
       restore_value: true
     power_demand_divider:
-      name: "${name} power demand divider"
+      name: "power demand divider"
       initial_value: 1
       restore_value: true
 
@@ -117,31 +117,31 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${name} power demand"
+      name: "power demand"
 
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
       id: operation_status_id0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
 
   # mqtt subscribe example
   - id: powermeter0
     internal: true
     platform: mqtt_subscribe
-    name: "${name} instantaneous power consumption"
+    name: "instantaneous power consumption"
     topic: "smartmeter/sensor/groundfloor/obis/1-0:16.7.0/255/value"
     accuracy_decimals: 2
     unit_of_measurement: W
@@ -153,7 +153,7 @@ sensor:
 #   # requires the "api" component see above
 #   - platform: homeassistant
 #     id: powermeter0
-#     name: "${name} smartmeter instantaneous power"
+#     name: "smartmeter instantaneous power"
 #     entity_id: sensor.firstfloor_smartmeter_instantaneous_power
 #     filters:
 #       - throttle_average: 15s
@@ -162,19 +162,19 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${name} manual mode"
+      name: "manual mode"
       restore_mode: RESTORE_DEFAULT_ON
     emergency_power_off:
-      name: "${name} emergency power off"
+      name: "emergency power off"
       restore_mode: RESTORE_DEFAULT_OFF
 
 text_sensor:
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"
 
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${name} limiter operation mode"
+      name: "limiter operation mode"

--- a/esp32-limiter-example.yaml
+++ b/esp32-limiter-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp32-limiter-example.yaml
+++ b/esp32-limiter-example.yaml
@@ -84,19 +84,19 @@ number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${name} buffer"
+      name: "buffer"
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${name} manual power demand"
+      name: "manual power demand"
       max_value: 900
     max_power_demand:
-      name: "${name} max power demand"
+      name: "max power demand"
       initial_value: 600
       max_value: 900
       restore_value: true
     power_demand_divider:
-      name: "${name} power demand divider"
+      name: "power demand divider"
       initial_value: 1
       restore_value: true
 
@@ -104,13 +104,13 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${name} power demand"
+      name: "power demand"
 
   # mqtt subscribe example
   - id: powermeter0
     internal: true
     platform: mqtt_subscribe
-    name: "${name} instantaneous power consumption"
+    name: "instantaneous power consumption"
     topic: "smartmeter/sensor/groundfloor/obis/1-0:16.7.0/255/value"
     accuracy_decimals: 2
     unit_of_measurement: W
@@ -122,7 +122,7 @@ sensor:
 #   # requires the "api" component see above
 #   - platform: homeassistant
 #     id: powermeter0
-#     name: "${name} smartmeter instantaneous power"
+#     name: "smartmeter instantaneous power"
 #     entity_id: sensor.firstfloor_smartmeter_instantaneous_power
 #     filters:
 #       - throttle_average: 15s
@@ -131,14 +131,14 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${name} manual mode"
+      name: "manual mode"
       restore_mode: RESTORE_DEFAULT_ON
     emergency_power_off:
-      name: "${name} emergency power off"
+      name: "emergency power off"
       restore_mode: RESTORE_DEFAULT_OFF
 
 text_sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${name} limiter operation mode"
+      name: "limiter operation mode"

--- a/esp32-multiple-uarts-example.yaml
+++ b/esp32-multiple-uarts-example.yaml
@@ -11,6 +11,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-display-display-version-example.yaml
+++ b/esp8266-display-display-version-example.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-display-display-version-example.yaml
+++ b/esp8266-display-display-version-example.yaml
@@ -49,31 +49,31 @@ soyosource_display:
 binary_sensor:
   - platform: soyosource_display
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
     limiter_connected:
-      name: "${name} limiter connected"
+      name: "limiter connected"
 
 button:
   - platform: soyosource_display
     restart:
-      name: "${name} restart"
+      name: "restart"
 
 number:
   - platform: soyosource_display
     start_voltage:
-      name: "${name} start voltage"
+      name: "start voltage"
     shutdown_voltage:
-      name: "${name} shutdown voltage"
+      name: "shutdown voltage"
     # Maximum output power in limiter mode / Output power in constant power mode
     output_power_limit:
-      name: "${name} output power limit"
+      name: "output power limit"
     start_delay:
-      name: "${name} start delay"
+      name: "start delay"
 
 select:
   - platform: soyosource_display
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
       optionsmap:
         1: "PV"
         2: "Battery Constant Power"
@@ -82,32 +82,32 @@ select:
 sensor:
   - platform: soyosource_display
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     operation_mode_id:
-      name: "${name} operation mode id"
+      name: "operation mode id"
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
       id: operation_status_id0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     output_power:
-      name: "${name} output power"
+      name: "output power"
 
 text_sensor:
   - platform: soyosource_display
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"

--- a/esp8266-display-display-version-limiter-example.yaml
+++ b/esp8266-display-display-version-limiter-example.yaml
@@ -100,50 +100,50 @@ soyosource_display:
 binary_sensor:
   - platform: soyosource_display
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
     limiter_connected:
-      name: "${name} limiter connected"
+      name: "limiter connected"
 
 button:
   - platform: soyosource_display
     restart:
-      name: "${name} restart"
+      name: "restart"
 
 number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${name} buffer"
+      name: "buffer"
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${name} manual power demand"
+      name: "manual power demand"
       max_value: 900
     max_power_demand:
-      name: "${name} max power demand"
+      name: "max power demand"
       initial_value: 600
       max_value: 900
       restore_value: true
     power_demand_divider:
-      name: "${name} power demand divider"
+      name: "power demand divider"
       initial_value: 1
       restore_value: true
 
   - platform: soyosource_display
     start_voltage:
-      name: "${name} start voltage"
+      name: "start voltage"
     shutdown_voltage:
-      name: "${name} shutdown voltage"
+      name: "shutdown voltage"
     # Maximum output power in limiter mode / Output power in constant power mode
     output_power_limit:
-      name: "${name} output power limit"
+      name: "output power limit"
     start_delay:
-      name: "${name} start delay"
+      name: "start delay"
 
 select:
   - platform: soyosource_display
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
       optionsmap:
         1: "Battery Constant Power"
         2: "PV"
@@ -153,36 +153,36 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${name} power demand"
+      name: "power demand"
 
   - platform: soyosource_display
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     operation_mode_id:
-      name: "${name} operation mode id"
+      name: "operation mode id"
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
       id: operation_status_id0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     output_power:
-      name: "${name} output power"
+      name: "output power"
 
   # mqtt subscribe example
   - id: powermeter0
     internal: true
     platform: mqtt_subscribe
-    name: "${name} instantaneous power consumption"
+    name: "instantaneous power consumption"
     topic: "smartmeter/sensor/groundfloor/obis/1-0:16.7.0/255/value"
     accuracy_decimals: 2
     unit_of_measurement: W
@@ -194,7 +194,7 @@ sensor:
 #   # requires the "api" component see above
 #   - platform: homeassistant
 #     id: powermeter0
-#     name: "${name} smartmeter instantaneous power"
+#     name: "smartmeter instantaneous power"
 #     entity_id: sensor.firstfloor_smartmeter_instantaneous_power
 #     filters:
 #       - throttle_average: 15s
@@ -203,22 +203,22 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${name} manual mode"
+      name: "manual mode"
       restore_mode: RESTORE_DEFAULT_ON
     emergency_power_off:
-      name: "${name} emergency power off"
+      name: "emergency power off"
       restore_mode: RESTORE_DEFAULT_OFF
 
 text_sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${name} limiter operation mode"
+      name: "limiter operation mode"
 
   - platform: soyosource_display
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"

--- a/esp8266-display-display-version-limiter-example.yaml
+++ b/esp8266-display-display-version-limiter-example.yaml
@@ -11,6 +11,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-display-wifi-version-example.yaml
+++ b/esp8266-display-wifi-version-example.yaml
@@ -56,31 +56,31 @@ soyosource_display:
 binary_sensor:
   - platform: soyosource_display
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
     limiter_connected:
-      name: "${name} limiter connected"
+      name: "limiter connected"
 
 button:
   - platform: soyosource_display
     restart:
-      name: "${name} restart"
+      name: "restart"
 
 number:
   - platform: soyosource_display
     start_voltage:
-      name: "${name} start voltage"
+      name: "start voltage"
     shutdown_voltage:
-      name: "${name} shutdown voltage"
+      name: "shutdown voltage"
     # Maximum output power in limiter mode / Output power in constant power mode
     output_power_limit:
-      name: "${name} output power limit"
+      name: "output power limit"
     start_delay:
-      name: "${name} start delay"
+      name: "start delay"
 
 select:
   - platform: soyosource_display
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
       optionsmap:
         1: "PV"
         2: "Battery Constant Power"
@@ -90,32 +90,32 @@ select:
 sensor:
   - platform: soyosource_display
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     operation_mode_id:
-      name: "${name} operation mode id"
+      name: "operation mode id"
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
       id: operation_status_id0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     output_power:
-      name: "${name} output power"
+      name: "output power"
 
 text_sensor:
   - platform: soyosource_display
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"

--- a/esp8266-display-wifi-version-example.yaml
+++ b/esp8266-display-wifi-version-example.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-display-wifi-version-limiter-example.yaml
+++ b/esp8266-display-wifi-version-limiter-example.yaml
@@ -100,50 +100,50 @@ soyosource_display:
 binary_sensor:
   - platform: soyosource_display
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
     limiter_connected:
-      name: "${name} limiter connected"
+      name: "limiter connected"
 
 button:
   - platform: soyosource_display
     restart:
-      name: "${name} restart"
+      name: "restart"
 
 number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${name} buffer"
+      name: "buffer"
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${name} manual power demand"
+      name: "manual power demand"
       max_value: 900
     max_power_demand:
-      name: "${name} max power demand"
+      name: "max power demand"
       initial_value: 600
       max_value: 900
       restore_value: true
     power_demand_divider:
-      name: "${name} power demand divider"
+      name: "power demand divider"
       initial_value: 1
       restore_value: true
 
   - platform: soyosource_display
     start_voltage:
-      name: "${name} start voltage"
+      name: "start voltage"
     shutdown_voltage:
-      name: "${name} shutdown voltage"
+      name: "shutdown voltage"
     # Maximum output power in limiter mode / Output power in constant power mode
     output_power_limit:
-      name: "${name} output power limit"
+      name: "output power limit"
     start_delay:
-      name: "${name} start delay"
+      name: "start delay"
 
 select:
   - platform: soyosource_display
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
       optionsmap:
         1: "PV"
         2: "Battery Constant Power"
@@ -154,36 +154,36 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${name} power demand"
+      name: "power demand"
 
   - platform: soyosource_display
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     operation_mode_id:
-      name: "${name} operation mode id"
+      name: "operation mode id"
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
       id: operation_status_id0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     output_power:
-      name: "${name} output power"
+      name: "output power"
 
   # mqtt subscribe example
   - id: powermeter0
     internal: true
     platform: mqtt_subscribe
-    name: "${name} instantaneous power consumption"
+    name: "instantaneous power consumption"
     topic: "smartmeter/sensor/groundfloor/obis/1-0:16.7.0/255/value"
     accuracy_decimals: 2
     unit_of_measurement: W
@@ -195,7 +195,7 @@ sensor:
 #   # requires the "api" component see above
 #   - platform: homeassistant
 #     id: powermeter0
-#     name: "${name} smartmeter instantaneous power"
+#     name: "smartmeter instantaneous power"
 #     entity_id: sensor.firstfloor_smartmeter_instantaneous_power
 #     filters:
 #       - throttle_average: 15s
@@ -204,22 +204,22 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${name} manual mode"
+      name: "manual mode"
       restore_mode: RESTORE_DEFAULT_ON
     emergency_power_off:
-      name: "${name} emergency power off"
+      name: "emergency power off"
       restore_mode: RESTORE_DEFAULT_OFF
 
 text_sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${name} limiter operation mode"
+      name: "limiter operation mode"
 
   - platform: soyosource_display
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"

--- a/esp8266-display-wifi-version-limiter-example.yaml
+++ b/esp8266-display-wifi-version-limiter-example.yaml
@@ -11,6 +11,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -91,25 +91,25 @@ binary_sensor:
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
 
 number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${name} buffer"
+      name: "buffer"
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${name} manual power demand"
+      name: "manual power demand"
       max_value: 900
     max_power_demand:
-      name: "${name} max power demand"
+      name: "max power demand"
       initial_value: 600
       max_value: 900
       restore_value: true
     power_demand_divider:
-      name: "${name} power demand divider"
+      name: "power demand divider"
       initial_value: 1
       restore_value: true
 
@@ -117,31 +117,31 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${name} power demand"
+      name: "power demand"
 
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
       id: operation_status_id0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
 
   # mqtt subscribe example
   - id: powermeter0
     internal: true
     platform: mqtt_subscribe
-    name: "${name} instantaneous power consumption"
+    name: "instantaneous power consumption"
     topic: "smartmeter/sensor/groundfloor/obis/1-0:16.7.0/255/value"
     accuracy_decimals: 2
     unit_of_measurement: W
@@ -153,7 +153,7 @@ sensor:
 #   # requires the "api" component see above
 #   - platform: homeassistant
 #     id: powermeter0
-#     name: "${name} smartmeter instantaneous power"
+#     name: "smartmeter instantaneous power"
 #     entity_id: sensor.firstfloor_smartmeter_instantaneous_power
 #     filters:
 #       - throttle_average: 15s
@@ -162,19 +162,19 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${name} manual mode"
+      name: "manual mode"
       restore_mode: RESTORE_DEFAULT_ON
     emergency_power_off:
-      name: "${name} emergency power off"
+      name: "emergency power off"
       restore_mode: RESTORE_DEFAULT_OFF
 
 text_sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${name} limiter operation mode"
+      name: "limiter operation mode"
 
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-limiter-example.yaml
+++ b/esp8266-limiter-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-limiter-example.yaml
+++ b/esp8266-limiter-example.yaml
@@ -84,19 +84,19 @@ number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${name} buffer"
+      name: "buffer"
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${name} manual power demand"
+      name: "manual power demand"
       max_value: 900
     max_power_demand:
-      name: "${name} max power demand"
+      name: "max power demand"
       initial_value: 600
       max_value: 900
       restore_value: true
     power_demand_divider:
-      name: "${name} power demand divider"
+      name: "power demand divider"
       initial_value: 1
       restore_value: true
 
@@ -104,13 +104,13 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${name} power demand"
+      name: "power demand"
 
   # mqtt subscribe example
   - id: powermeter0
     internal: true
     platform: mqtt_subscribe
-    name: "${name} instantaneous power consumption"
+    name: "instantaneous power consumption"
     topic: "smartmeter/sensor/groundfloor/obis/1-0:16.7.0/255/value"
     accuracy_decimals: 2
     unit_of_measurement: W
@@ -122,7 +122,7 @@ sensor:
 #   # requires the "api" component see above
 #   - platform: homeassistant
 #     id: powermeter0
-#     name: "${name} smartmeter instantaneous power"
+#     name: "smartmeter instantaneous power"
 #     entity_id: sensor.firstfloor_smartmeter_instantaneous_power
 #     filters:
 #       - throttle_average: 15s
@@ -131,14 +131,14 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${name} manual mode"
+      name: "manual mode"
       restore_mode: RESTORE_DEFAULT_ON
     emergency_power_off:
-      name: "${name} emergency power off"
+      name: "emergency power off"
       restore_mode: RESTORE_DEFAULT_OFF
 
 text_sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${name} limiter operation mode"
+      name: "limiter operation mode"

--- a/esp8266-wifi-dongle-example-web-only.yaml
+++ b/esp8266-wifi-dongle-example-web-only.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-wifi-dongle-example.yaml
+++ b/esp8266-wifi-dongle-example.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/esp8266-wifi-dongle-example.yaml
+++ b/esp8266-wifi-dongle-example.yaml
@@ -52,31 +52,31 @@ soyosource_display:
 binary_sensor:
   - platform: soyosource_display
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
     limiter_connected:
-      name: "${name} limiter connected"
+      name: "limiter connected"
 
 button:
   - platform: soyosource_display
     restart:
-      name: "${name} restart"
+      name: "restart"
 
 number:
   - platform: soyosource_display
     start_voltage:
-      name: "${name} start voltage"
+      name: "start voltage"
     shutdown_voltage:
-      name: "${name} shutdown voltage"
+      name: "shutdown voltage"
     # Maximum output power in limiter mode / Output power in constant power mode
     output_power_limit:
-      name: "${name} output power limit"
+      name: "output power limit"
     start_delay:
-      name: "${name} start delay"
+      name: "start delay"
 
 select:
   - platform: soyosource_display
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
       optionsmap:
         1: "PV"
         2: "Battery Constant Power"
@@ -86,33 +86,33 @@ select:
 sensor:
   - platform: soyosource_display
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     operation_mode_id:
-      name: "${name} operation mode id"
+      name: "operation mode id"
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     total_energy:
-      name: "${name} total energy"
+      name: "total energy"
     output_power:
-      name: "${name} output power"
+      name: "output power"
 
 text_sensor:
   - platform: soyosource_display
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"

--- a/esp8266-wifi-dongle-limiter-example.yaml
+++ b/esp8266-wifi-dongle-limiter-example.yaml
@@ -96,50 +96,50 @@ soyosource_display:
 binary_sensor:
   - platform: soyosource_display
     fan_running:
-      name: "${name} fan running"
+      name: "fan running"
     limiter_connected:
-      name: "${name} limiter connected"
+      name: "limiter connected"
 
 button:
   - platform: soyosource_display
     restart:
-      name: "${name} restart"
+      name: "restart"
 
 number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${name} buffer"
+      name: "buffer"
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${name} manual power demand"
+      name: "manual power demand"
       max_value: 900
     max_power_demand:
-      name: "${name} max power demand"
+      name: "max power demand"
       initial_value: 600
       max_value: 900
       restore_value: true
     power_demand_divider:
-      name: "${name} power demand divider"
+      name: "power demand divider"
       initial_value: 1
       restore_value: true
 
   - platform: soyosource_display
     start_voltage:
-      name: "${name} start voltage"
+      name: "start voltage"
     shutdown_voltage:
-      name: "${name} shutdown voltage"
+      name: "shutdown voltage"
     # Maximum output power in limiter mode / Output power in constant power mode
     output_power_limit:
-      name: "${name} output power limit"
+      name: "output power limit"
     start_delay:
-      name: "${name} start delay"
+      name: "start delay"
 
 select:
   - platform: soyosource_display
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
       optionsmap:
         1: "PV"
         2: "Battery Constant Power"
@@ -150,38 +150,38 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${name} power demand"
+      name: "power demand"
 
   - platform: soyosource_display
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     operation_mode_id:
-      name: "${name} operation mode id"
+      name: "operation mode id"
     operation_status_id:
-      name: "${name} operation status id"
+      name: "operation status id"
       id: operation_status_id0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_power:
-      name: "${name} battery power"
+      name: "battery power"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     total_energy:
-      name: "${name} total energy"
+      name: "total energy"
     output_power:
-      name: "${name} output power"
+      name: "output power"
 
   # mqtt subscribe example
   - id: powermeter0
     internal: true
     platform: mqtt_subscribe
-    name: "${name} instantaneous power consumption"
+    name: "instantaneous power consumption"
     topic: "smartmeter/sensor/groundfloor/obis/1-0:16.7.0/255/value"
     accuracy_decimals: 2
     unit_of_measurement: W
@@ -193,7 +193,7 @@ sensor:
 #   # requires the "api" component see above
 #   - platform: homeassistant
 #     id: powermeter0
-#     name: "${name} smartmeter instantaneous power"
+#     name: "smartmeter instantaneous power"
 #     entity_id: sensor.firstfloor_smartmeter_instantaneous_power
 #     filters:
 #       - throttle_average: 15s
@@ -202,22 +202,22 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${name} manual mode"
+      name: "manual mode"
       restore_mode: RESTORE_DEFAULT_ON
     emergency_power_off:
-      name: "${name} emergency power off"
+      name: "emergency power off"
       restore_mode: RESTORE_DEFAULT_OFF
 
 text_sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${name} limiter operation mode"
+      name: "limiter operation mode"
 
   - platform: soyosource_display
     errors:
-      name: "${name} errors"
+      name: "errors"
     operation_mode:
-      name: "${name} operation mode"
+      name: "operation mode"
     operation_status:
-      name: "${name} operation status"
+      name: "operation status"

--- a/esp8266-wifi-dongle-limiter-example.yaml
+++ b/esp8266-wifi-dongle-limiter-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp8266-display-rx.yaml
+++ b/tests/esp8266-display-rx.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-inverter-display-version-emulator.yaml
+++ b/tests/esp8266-inverter-display-version-emulator.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/tests/esp8266-inverter-wifi-version-emulator.yaml
+++ b/tests/esp8266-inverter-wifi-version-emulator.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"

--- a/tests/esp8266-limiter-rx.yaml
+++ b/tests/esp8266-limiter-rx.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-limiter-tx.yaml
+++ b/tests/esp8266-limiter-tx.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-powermeter-esphome-http-rest-api.yaml
+++ b/tests/esp8266-powermeter-esphome-http-rest-api.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-powermeter-homeassistant-native-api.yaml
+++ b/tests/esp8266-powermeter-homeassistant-native-api.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-powermeter-mqtt-topic.yaml
+++ b/tests/esp8266-powermeter-mqtt-topic.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-powermeter-shelly-3em-http-status-json.yaml
+++ b/tests/esp8266-powermeter-shelly-3em-http-status-json.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-powermeter-tasmota-http-status-sns-en.yaml
+++ b/tests/esp8266-powermeter-tasmota-http-status-sns-en.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-powermeter-tasmota-http-status-sns.yaml
+++ b/tests/esp8266-powermeter-tasmota-http-status-sns.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.