### PR TITLE
Extend CONFIG_SCHEMA with cv.COMPONENT_SCHEMA

### DIFF
--- a/components/soyosource_inverter_emulator/__init__.py
+++ b/components/soyosource_inverter_emulator/__init__.py
@@ -23,14 +23,18 @@ PROTOCOL_VERSION_OPTIONS = {
     "SOYOSOURCE_DISPLAY_VERSION": ProtocolVersion.SOYOSOURCE_DISPLAY_VERSION,
 }
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(SoyosourceInverterEmulator),
-        cv.Optional(CONF_PROTOCOL_VERSION, default="SOYOSOURCE_WIFI_VERSION"): cv.enum(
-            PROTOCOL_VERSION_OPTIONS, upper=True
-        ),
-    }
-).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(SoyosourceInverterEmulator),
+            cv.Optional(
+                CONF_PROTOCOL_VERSION, default="SOYOSOURCE_WIFI_VERSION"
+            ): cv.enum(PROTOCOL_VERSION_OPTIONS, upper=True),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):


### PR DESCRIPTION
## Summary

`SoyosourceInverterEmulator` inherits from `cg.Component` and its `to_code` calls `register_component()`, but `CONFIG_SCHEMA` was missing `.extend(cv.COMPONENT_SCHEMA)`.

Without it the `setup_priority` key is not accepted in YAML configuration.

## Root cause

`uart.UART_DEVICE_SCHEMA` only provides the parent UART reference — it does not include `cv.COMPONENT_SCHEMA`. Components that use UART as a bus must add `cv.COMPONENT_SCHEMA` (or `cv.polling_component_schema`) explicitly.