### PR TITLE
Improve ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ disable = [
 expected-line-ending-format = "LF"
 
 [tool.ruff]
-required-version = ">=0.5.0"
+required-version = ">=0.5.5"
 target-version = "py311"
 
 [tool.ruff.lint]


### PR DESCRIPTION
- Bump \`required-version\` to \`>=0.5.5\` to match the pinned pre-commit hook version
- Add \`src\` paths so ruff resolves imports correctly across \`components\` and \`tests\`