### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/soyosource_display/soyosource_display.cpp
+++ b/components/soyosource_display/soyosource_display.cpp
@@ -24,7 +24,7 @@ static const uint8_t FRAME_TYPE_MS51_V2_SETTINGS = 0x17;
 static const uint8_t FRAME_TYPE_MS51_V2_STATUS = 0x19;
 
 static const uint8_t ERRORS_SIZE = 8;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     "Reserved (Bit 1)",     // 0000 0001
     "DC voltage too low",   // 0000 0010
     "DC voltage too high",  // 0000 0100

--- a/components/soyosource_inverter/soyosource_inverter.cpp
+++ b/components/soyosource_inverter/soyosource_inverter.cpp
@@ -7,7 +7,7 @@ namespace soyosource_inverter {
 static const char *const TAG = "soyosource_inverter";
 
 static const uint8_t OPERATION_STATUS_SIZE = 13;
-static const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
+static constexpr const char *const OPERATION_STATUS[OPERATION_STATUS_SIZE] = {
     "Normal",                  // 0x00
     "Startup",                 // 0x01
     "Standby",                 // 0x02


### PR DESCRIPTION
## Summary

- Replace `static const char *const` array declarations with `static constexpr const char *const` in affected components

## Details

Using `static constexpr const char *const` for string arrays ensures that:

- The arrays are evaluated at **compile time** and placed in the **read-only segment (Flash)** rather than consuming RAM at runtime
- This matches the style used in the ESPHome core (e.g. `bme68x_bsec2.cpp`) and is the recommended pattern for constant string lookup tables in embedded firmware

## Affected files

- `components/soyosource_inverter/soyosource_inverter.cpp` (line 10): `OPERATION_STATUS` array
- `components/soyosource_display/soyosource_display.cpp` (line 27): `ERRORS` array

Note: single `TAG` string constants (`static const char *const TAG`) are intentionally left unchanged as they are not arrays and the change is not applicable there.