### PR TITLE
Use ESP-IDF framework

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -15,6 +15,8 @@ esphome:
 
 esp32:
   board: esp-wrover-kit
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-limiter-example.yaml
+++ b/esp32-limiter-example.yaml
@@ -15,6 +15,8 @@ esphome:
 
 esp32:
   board: esp-wrover-kit
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-multiple-uarts-example.yaml
+++ b/esp32-multiple-uarts-example.yaml
@@ -19,6 +19,8 @@ esphome:
 
 esp32:
   board: esp-wrover-kit
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}


### PR DESCRIPTION
## Summary
- Switch from Arduino to ESP-IDF framework per ESPHome 2026.1.0 deprecation warning