### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/soyosource_display/button/soyosource_button.cpp
+++ b/components/soyosource_display/button/soyosource_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 static const char *const TAG = "soyosource_display.button";
 
 void SoyosourceButton::dump_config() { LOG_BUTTON("", "SoyosourceDisplay Button", this); }
 void SoyosourceButton::press_action() { this->parent_->send_command(this->holding_register_); }
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_display/button/soyosource_button.h
+++ b/components/soyosource_display/button/soyosource_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 class SoyosourceDisplay;
 
@@ -23,5 +22,4 @@ class SoyosourceButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_display/number/soyosource_number.cpp
+++ b/components/soyosource_display/number/soyosource_number.cpp
@@ -1,13 +1,11 @@
 #include "soyosource_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 static const char *const TAG = "soyosource_display.number";
 
 void SoyosourceNumber::dump_config() { LOG_NUMBER("", "SoyosourceDisplay Number", this); }
 void SoyosourceNumber::control(float value) { this->parent_->update_setting(this->holding_register_, value); }
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_display/number/soyosource_number.h
+++ b/components/soyosource_display/number/soyosource_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 class SoyosourceDisplay;
 
@@ -22,5 +21,4 @@ class SoyosourceNumber : public number::Number, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_display/select/soyosource_select.cpp
+++ b/components/soyosource_display/select/soyosource_select.cpp
@@ -1,8 +1,7 @@
 #include "soyosource_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 static const char *const TAG = "soyosource_display.select";
 
@@ -43,5 +42,4 @@ void SoyosourceSelect::control(const std::string &value) {
   ESP_LOGW(TAG, "Invalid value %s", value.c_str());
 }
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_display/select/soyosource_select.h
+++ b/components/soyosource_display/select/soyosource_select.h
@@ -7,8 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/select/select.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 class SoyosourceDisplay;
 
@@ -29,5 +28,4 @@ class SoyosourceSelect : public select::Select, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_display/soyosource_display.cpp
+++ b/components/soyosource_display/soyosource_display.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 static const char *const TAG = "soyosource_display";
 
@@ -908,5 +907,4 @@ void SoyosourceDisplay::publish_state_(text_sensor::TextSensor *text_sensor, con
   text_sensor->publish_state(state);
 }
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_display/soyosource_display.h
+++ b/components/soyosource_display/soyosource_display.h
@@ -8,8 +8,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace soyosource_display {
+namespace esphome::soyosource_display {
 
 enum ProtocolVersion {
   SOYOSOURCE_WIFI_VERSION,
@@ -155,5 +154,4 @@ class SoyosourceDisplay : public uart::UARTDevice, public PollingComponent {
   std::string error_bits_to_string_(const uint8_t &mask);
 };
 
-}  // namespace soyosource_display
-}  // namespace esphome
+}  // namespace esphome::soyosource_display

--- a/components/soyosource_inverter/soyosource_inverter.cpp
+++ b/components/soyosource_inverter/soyosource_inverter.cpp
@@ -1,8 +1,7 @@
 #include "soyosource_inverter.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace soyosource_inverter {
+namespace esphome::soyosource_inverter {
 
 static const char *const TAG = "soyosource_inverter";
 
@@ -158,5 +157,4 @@ void SoyosourceInverter::dump_config() {
   LOG_BINARY_SENSOR("", "Fan Running", this->fan_running_binary_sensor_);
 }
 
-}  // namespace soyosource_inverter
-}  // namespace esphome
+}  // namespace esphome::soyosource_inverter

--- a/components/soyosource_inverter/soyosource_inverter.h
+++ b/components/soyosource_inverter/soyosource_inverter.h
@@ -6,8 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/soyosource_modbus/soyosource_modbus.h"
 
-namespace esphome {
-namespace soyosource_inverter {
+namespace esphome::soyosource_inverter {
 
 static const uint8_t NO_RESPONSE_THRESHOLD = 15;
 
@@ -62,5 +61,4 @@ class SoyosourceInverter : public PollingComponent, public soyosource_modbus::So
   void publish_device_offline_();
 };
 
-}  // namespace soyosource_inverter
-}  // namespace esphome
+}  // namespace esphome::soyosource_inverter

--- a/components/soyosource_inverter_emulator/soyosource_inverter_emulator.cpp
+++ b/components/soyosource_inverter_emulator/soyosource_inverter_emulator.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace soyosource_inverter_emulator {
+namespace esphome::soyosource_inverter_emulator {
 
 static const char *const TAG = "soyosource_inverter_emulator";
 
@@ -339,5 +338,4 @@ void SoyosourceInverterEmulator::send_settings_(const uint16_t &unknown1, const 
   this->flush();
 }
 
-}  // namespace soyosource_inverter_emulator
-}  // namespace esphome
+}  // namespace esphome::soyosource_inverter_emulator

--- a/components/soyosource_inverter_emulator/soyosource_inverter_emulator.h
+++ b/components/soyosource_inverter_emulator/soyosource_inverter_emulator.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace soyosource_inverter_emulator {
+namespace esphome::soyosource_inverter_emulator {
 
 enum ProtocolVersion {
   SOYOSOURCE_WIFI_VERSION,
@@ -41,5 +40,4 @@ class SoyosourceInverterEmulator : public uart::UARTDevice, public Component {
   std::string operation_status_to_string_(const uint8_t &operation_status);
 };
 
-}  // namespace soyosource_inverter_emulator
-}  // namespace esphome
+}  // namespace esphome::soyosource_inverter_emulator

--- a/components/soyosource_modbus/soyosource_modbus.cpp
+++ b/components/soyosource_modbus/soyosource_modbus.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace soyosource_modbus {
+namespace esphome::soyosource_modbus {
 
 static const char *const TAG = "soyosource_modbus";
 
@@ -144,5 +143,4 @@ void SoyosourceModbus::query_status() {
     this->flow_control_pin_->digital_write(false);
 }
 
-}  // namespace soyosource_modbus
-}  // namespace esphome
+}  // namespace esphome::soyosource_modbus

--- a/components/soyosource_modbus/soyosource_modbus.h
+++ b/components/soyosource_modbus/soyosource_modbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace soyosource_modbus {
+namespace esphome::soyosource_modbus {
 
 class SoyosourceModbusDevice;
 
@@ -59,5 +58,4 @@ class SoyosourceModbusDevice {
   uint8_t address_;
 };
 
-}  // namespace soyosource_modbus
-}  // namespace esphome
+}  // namespace esphome::soyosource_modbus

--- a/components/soyosource_virtual_meter/number/soyosource_number.cpp
+++ b/components/soyosource_virtual_meter/number/soyosource_number.cpp
@@ -1,8 +1,7 @@
 #include "soyosource_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace soyosource_virtual_meter {
+namespace esphome::soyosource_virtual_meter {
 
 static const char *const TAG = "soyosource_virtual_meter.number";
 
@@ -49,5 +48,4 @@ void SoyosourceNumber::apply_and_publish_(float value) {
 
 void SoyosourceNumber::dump_config() { LOG_NUMBER("", "SoyosourceVirtualMeter Number", this); }
 
-}  // namespace soyosource_virtual_meter
-}  // namespace esphome
+}  // namespace esphome::soyosource_virtual_meter

--- a/components/soyosource_virtual_meter/number/soyosource_number.h
+++ b/components/soyosource_virtual_meter/number/soyosource_number.h
@@ -5,8 +5,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace soyosource_virtual_meter {
+namespace esphome::soyosource_virtual_meter {
 
 class SoyosourceVirtualMeter;
 
@@ -32,5 +31,4 @@ class SoyosourceNumber : public number::Number, public Component {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace soyosource_virtual_meter
-}  // namespace esphome
+}  // namespace esphome::soyosource_virtual_meter

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.cpp
@@ -1,8 +1,7 @@
 #include "soyosource_virtual_meter.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace soyosource_virtual_meter {
+namespace esphome::soyosource_virtual_meter {
 
 static const char *const TAG = "soyosource_virtual_meter";
 
@@ -205,5 +204,4 @@ void SoyosourceVirtualMeter::publish_state_(text_sensor::TextSensor *text_sensor
   text_sensor->publish_state(state);
 }
 
-}  // namespace soyosource_virtual_meter
-}  // namespace esphome
+}  // namespace esphome::soyosource_virtual_meter

--- a/components/soyosource_virtual_meter/soyosource_virtual_meter.h
+++ b/components/soyosource_virtual_meter/soyosource_virtual_meter.h
@@ -7,8 +7,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/soyosource_modbus/soyosource_modbus.h"
 
-namespace esphome {
-namespace soyosource_virtual_meter {
+namespace esphome::soyosource_virtual_meter {
 
 enum PowerDemandCalculation {
   POWER_DEMAND_CALCULATION_DUMB_OEM_BEHAVIOR,
@@ -104,5 +103,4 @@ class SoyosourceVirtualMeter : public PollingComponent, public soyosource_modbus
   int16_t calculate_power_demand_oem_(int16_t consumption);
 };
 
-}  // namespace soyosource_virtual_meter
-}  // namespace esphome
+}  // namespace esphome::soyosource_virtual_meter

--- a/components/soyosource_virtual_meter/switch/soyosource_switch.cpp
+++ b/components/soyosource_virtual_meter/switch/soyosource_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace soyosource_virtual_meter {
+namespace esphome::soyosource_virtual_meter {
 
 static const char *const TAG = "soyosource_virtual_meter.switch";
 
@@ -54,5 +53,4 @@ void SoyosourceSwitch::dump_config() {
 }
 void SoyosourceSwitch::write_state(bool state) { this->publish_state(state); }
 
-}  // namespace soyosource_virtual_meter
-}  // namespace esphome
+}  // namespace esphome::soyosource_virtual_meter

--- a/components/soyosource_virtual_meter/switch/soyosource_switch.h
+++ b/components/soyosource_virtual_meter/switch/soyosource_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace soyosource_virtual_meter {
+namespace esphome::soyosource_virtual_meter {
 
 enum SoyosourceSwitchRestoreMode {
   SOYOSOURCE_SWITCH_RESTORE_DEFAULT_OFF,
@@ -30,5 +29,4 @@ class SoyosourceSwitch : public switch_::Switch, public Component {
   SoyosourceSwitchRestoreMode restore_mode_{SOYOSOURCE_SWITCH_RESTORE_DEFAULT_OFF};
 };
 
-}  // namespace soyosource_virtual_meter
-}  // namespace esphome
+}  // namespace esphome::soyosource_virtual_meter


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.