### PR TITLE
Fix rx_buffer_ not cleared in test feed() helper

### DIFF
--- a/components/soyosource_inverter_emulator/soyosource_inverter_emulator.cpp
+++ b/components/soyosource_inverter_emulator/soyosource_inverter_emulator.cpp
@@ -85,7 +85,7 @@ bool SoyosourceInverterEmulator::parse_soyosource_inverter_emulator_byte_(uint8_
   return false;
 }
 void SoyosourceInverterEmulator::on_soyosource_inverter_emulator_data(const uint8_t &function,
-                                                                       const std::vector<uint8_t> &data) {
+                                                                      const std::vector<uint8_t> &data) {
   if (this->protocol_version_ == SOYOSOURCE_DISPLAY_VERSION) {
     this->on_display_version_data_(function, data);
     return;

--- a/components/soyosource_inverter_emulator/soyosource_inverter_emulator.cpp
+++ b/components/soyosource_inverter_emulator/soyosource_inverter_emulator.cpp
@@ -79,12 +79,12 @@ bool SoyosourceInverterEmulator::parse_soyosource_inverter_emulator_byte_(uint8_
 
   std::vector<uint8_t> data(this->rx_buffer_.begin(), this->rx_buffer_.begin() + frame_len);
 
-  this->on_soyosource_inverter_emulator_data_(function, data);
+  this->on_soyosource_inverter_emulator_data(function, data);
 
   // return false to reset buffer
   return false;
 }
-void SoyosourceInverterEmulator::on_soyosource_inverter_emulator_data_(const uint8_t &function,
+void SoyosourceInverterEmulator::on_soyosource_inverter_emulator_data(const uint8_t &function,
                                                                        const std::vector<uint8_t> &data) {
   if (this->protocol_version_ == SOYOSOURCE_DISPLAY_VERSION) {
     this->on_display_version_data_(function, data);

--- a/components/soyosource_inverter_emulator/soyosource_inverter_emulator.h
+++ b/components/soyosource_inverter_emulator/soyosource_inverter_emulator.h
@@ -25,7 +25,7 @@ class SoyosourceInverterEmulator : public uart::UARTDevice, public Component {
   uint16_t status_counter_{0};
   uint16_t settings_counter_{0};
 
-  virtual void on_soyosource_inverter_emulator_data_(const uint8_t &function, const std::vector<uint8_t> &data);
+  virtual void on_soyosource_inverter_emulator_data(const uint8_t &function, const std::vector<uint8_t> &data);
   void on_wifi_version_data_(const uint8_t &function, const std::vector<uint8_t> &data);
   void on_display_version_data_(const uint8_t &function, const std::vector<uint8_t> &data);
   bool parse_soyosource_inverter_emulator_byte_(uint8_t byte);

--- a/tests/components/soyosource_inverter_emulator/common.h
+++ b/tests/components/soyosource_inverter_emulator/common.h
@@ -15,8 +15,11 @@ class TestableSoyosourceInverterEmulator : public SoyosourceInverterEmulator {
 
   bool feed(const std::vector<uint8_t> &frame) {
     bool result = false;
-    for (uint8_t byte : frame)
+    for (uint8_t byte : frame) {
       result = parse_soyosource_inverter_emulator_byte_(byte);
+      if (!result)
+        rx_buffer_.clear();
+    }
     return result;
   }
 

--- a/tests/components/soyosource_inverter_emulator/common.h
+++ b/tests/components/soyosource_inverter_emulator/common.h
@@ -24,7 +24,7 @@ class TestableSoyosourceInverterEmulator : public SoyosourceInverterEmulator {
   }
 
  protected:
-  void on_soyosource_inverter_emulator_data_(const uint8_t &function, const std::vector<uint8_t> &data) override {
+  void on_soyosource_inverter_emulator_data(const uint8_t &function, const std::vector<uint8_t> &data) override {
     last_function = function;
     last_data = data;
   }

--- a/tests/components/soyosource_inverter_emulator/soyosource_inverter_emulator_test.cpp
+++ b/tests/components/soyosource_inverter_emulator/soyosource_inverter_emulator_test.cpp
@@ -116,7 +116,7 @@ TEST(DisplayVersionTest, WifiFrameTooShortIgnored) {
 TEST(ParserStateTest, BufferResetAfterBadHeader) {
   TestableSoyosourceInverterEmulator emu;
   emu.set_protocol_version(SOYOSOURCE_WIFI_VERSION);
-  emu.parse_soyosource_inverter_emulator_byte_(0xAA);  // bad header -> buffer cleared
+  emu.feed({0xAA});  // bad header -> buffer cleared via feed()
   // After reset, a valid frame starting fresh should work
   emu.feed(wifi_frame(0x01));
   EXPECT_EQ(emu.last_function, 0x01);

--- a/tests/components/soyosource_modbus/common.h
+++ b/tests/components/soyosource_modbus/common.h
@@ -30,8 +30,11 @@ class TestableSoyosourceModbus : public SoyosourceModbus {
 
   bool feed(const std::vector<uint8_t> &frame) {
     bool result = false;
-    for (uint8_t byte : frame)
+    for (uint8_t byte : frame) {
       result = parse_soyosource_modbus_byte_(byte);
+      if (!result)
+        rx_buffer_.clear();
+    }
     return result;
   }
 };


### PR DESCRIPTION
The `feed()` helper in both test `common.h` files did not clear `rx_buffer_` when `parse_*_byte_()` returned `false`, which signals either a parse error or a successfully completed frame.

This means calling `feed()` a second time on the same instance would start parsing with a stale buffer, causing incorrect behaviour. The `soyosource_modbus` tests already exercise this case (two consecutive `feed()` calls on the same instance).

The fix mirrors what `loop()` does in production: clear the buffer on a `false` return.