### PR TITLE
Introduce SENSOR_DEFS in soyosource_virtual_meter and extend schema tests

### DIFF
--- a/components/soyosource_virtual_meter/sensor.py
+++ b/components/soyosource_virtual_meter/sensor.py
@@ -30,7 +30,10 @@ SENSOR_DEFS = {
 
 # pylint: disable=too-many-function-args
 CONFIG_SCHEMA = SOYOSOURCE_VIRTUAL_METER_COMPONENT_SCHEMA.extend(
-    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
+    {
+        cv.Optional(key): sensor.sensor_schema(**kwargs)
+        for key, kwargs in SENSOR_DEFS.items()
+    }
 )
 
 

--- a/components/soyosource_virtual_meter/sensor.py
+++ b/components/soyosource_virtual_meter/sensor.py
@@ -18,22 +18,25 @@ CODEOWNERS = ["@syssi"]
 
 CONF_POWER_DEMAND = "power_demand"
 
+SENSOR_DEFS = {
+    CONF_POWER_DEMAND: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+}
+
 # pylint: disable=too-many-function-args
 CONFIG_SCHEMA = SOYOSOURCE_VIRTUAL_METER_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_POWER_DEMAND): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
+    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_SOYOSOURCE_VIRTUAL_METER_ID])
-    if CONF_POWER_DEMAND in config:
-        sens = await sensor.new_sensor(config[CONF_POWER_DEMAND])
-        cg.add(hub.set_power_demand_sensor(sens))
+    for key in SENSOR_DEFS:
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(getattr(hub, f"set_{key}_sensor")(sens))

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -22,6 +22,7 @@ from components.soyosource_inverter import (  # noqa: E402
 import components.soyosource_virtual_meter as hub_vm  # noqa: E402
 from components.soyosource_virtual_meter import (  # noqa: E402
     number as vm_number,  # noqa: E402
+    sensor as vm_sensor,  # noqa: E402
     switch as vm_switch,  # noqa: E402
     text_sensor as vm_text_sensor,
 )
@@ -101,6 +102,15 @@ class TestInverterSensorLists:
             in inverter_text_sensor.TEXT_SENSORS
         )
         assert len(inverter_text_sensor.TEXT_SENSORS) == 1
+
+
+class TestVirtualMeterSensorDefs:
+    def test_sensor_defs_completeness(self):
+        assert vm_sensor.CONF_POWER_DEMAND in vm_sensor.SENSOR_DEFS
+        assert len(vm_sensor.SENSOR_DEFS) == 1
+
+    def test_sensor_defs_keys_match_schema(self):
+        assert set(vm_sensor.SENSOR_DEFS.keys()) == {vm_sensor.CONF_POWER_DEMAND}
 
 
 class TestVirtualMeterConstants:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -22,10 +22,10 @@ from components.soyosource_inverter import (  # noqa: E402
 import components.soyosource_virtual_meter as hub_vm  # noqa: E402
 from components.soyosource_virtual_meter import (  # noqa: E402
     number as vm_number,  # noqa: E402
-    sensor as vm_sensor,  # noqa: E402
     switch as vm_switch,  # noqa: E402
     text_sensor as vm_text_sensor,
 )
+import components.soyosource_virtual_meter.sensor as vm_sensor  # noqa: E402
 
 
 class TestHubConstants:


### PR DESCRIPTION
## Summary

- Replaces the inline `sensor.sensor_schema()` call in `soyosource_virtual_meter/sensor.py` with a `SENSOR_DEFS` dict
- Since both schema registration and code generation iterate over the same dict, it is structurally impossible to declare a sensor without registering it
- Adds `TestVirtualMeterSensorDefs` to `tests/test_component_schemas.py` covering the previously untested virtual meter sensor module

## Test plan

- [ ] `pytest tests/test_component_schemas.py` passes
- [ ] `soyosource_virtual_meter` sensor schema unchanged from user perspective (`power_demand` still optional)