### PR TITLE
Use ESPHome devices concept in multi-device example

### DIFF
--- a/esp32-multiple-uarts-example.yaml
+++ b/esp32-multiple-uarts-example.yaml
@@ -16,6 +16,11 @@ esphome:
   project:
     name: "syssi.esphome-soyosource-gtn-virtual-meter"
     version: 2.5.0
+  devices:
+    - id: device0
+      name: "${device0}"
+    - id: device1
+      name: "${device1}"
 
 esp32:
   board: esp-wrover-kit
@@ -118,44 +123,54 @@ binary_sensor:
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     fan_running:
-      name: "${device0} fan running"
+      name: "fan running"
+      device_id: device0
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter1
     fan_running:
-      name: "${device1} fan running"
+      name: "fan running"
+      device_id: device1
 
 number:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     buffer:
-      name: "${device0} buffer"
+      name: "buffer"
+      device_id: device0
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${device0} manual power demand"
+      name: "manual power demand"
+      device_id: device0
     max_power_demand:
-      name: "${device0} max power demand"
+      name: "max power demand"
+      device_id: device0
       initial_value: 600
       restore_value: true
     power_demand_divider:
-      name: "${device0} power demand divider"
+      name: "power demand divider"
+      device_id: device0
       initial_value: 1
       restore_value: true
 
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter1
     buffer:
-      name: "${device1} buffer"
+      name: "buffer"
+      device_id: device1
       initial_value: 10
       restore_value: true
     manual_power_demand:
-      name: "${device1} manual power demand"
+      name: "manual power demand"
+      device_id: device1
     max_power_demand:
-      name: "${device1} max power demand"
+      name: "max power demand"
+      device_id: device1
       initial_value: 600
       restore_value: true
     power_demand_divider:
-      name: "${device1} power demand divider"
+      name: "power demand divider"
+      device_id: device1
       initial_value: 1
       restore_value: true
 
@@ -163,46 +178,62 @@ sensor:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     power_demand:
-      name: "${device0} power demand"
+      name: "power demand"
+      device_id: device0
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter1
     power_demand:
-      name: "${device1} power demand"
+      name: "power demand"
+      device_id: device1
 
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     operation_status_id:
-      name: "${device0} operation status id"
+      name: "operation status id"
+      device_id: device0
       id: operation_status_id0
     battery_voltage:
-      name: "${device0} battery voltage"
+      name: "battery voltage"
+      device_id: device0
     battery_current:
-      name: "${device0} battery current"
+      name: "battery current"
+      device_id: device0
     battery_power:
-      name: "${device0} battery power"
+      name: "battery power"
+      device_id: device0
     ac_voltage:
-      name: "${device0} ac voltage"
+      name: "ac voltage"
+      device_id: device0
     ac_frequency:
-      name: "${device0} ac frequency"
+      name: "ac frequency"
+      device_id: device0
     temperature:
-      name: "${device0} temperature"
+      name: "temperature"
+      device_id: device0
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter1
     operation_status_id:
-      name: "${device1} operation status id"
+      name: "operation status id"
+      device_id: device1
       id: operation_status_id1
     battery_voltage:
-      name: "${device1} battery voltage"
+      name: "battery voltage"
+      device_id: device1
     battery_current:
-      name: "${device1} battery current"
+      name: "battery current"
+      device_id: device1
     battery_power:
-      name: "${device1} battery power"
+      name: "battery power"
+      device_id: device1
     ac_voltage:
-      name: "${device1} ac voltage"
+      name: "ac voltage"
+      device_id: device1
     ac_frequency:
-      name: "${device1} ac frequency"
+      name: "ac frequency"
+      device_id: device1
     temperature:
-      name: "${device1} temperature"
+      name: "temperature"
+      device_id: device1
 
   # mqtt subscribe example
   - id: powermeter0
@@ -243,27 +274,33 @@ switch:
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     manual_mode:
-      name: "${device0} manual mode"
+      name: "manual mode"
+      device_id: device0
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter1
     manual_mode:
-      name: "${device1} manual mode"
+      name: "manual mode"
+      device_id: device1
 
 text_sensor:
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter0
     operation_status:
-      name: "${device0} operation status"
+      name: "operation status"
+      device_id: device0
   - platform: soyosource_inverter
     soyosource_inverter_id: inverter1
     operation_status:
-      name: "${device1} operation status"
+      name: "operation status"
+      device_id: device1
 
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter0
     operation_mode:
-      name: "${device0} limiter operation mode"
+      name: "limiter operation mode"
+      device_id: device0
   - platform: soyosource_virtual_meter
     soyosource_virtual_meter_id: virtualmeter1
     operation_mode:
-      name: "${device1} limiter operation mode"
+      name: "limiter operation mode"
+      device_id: device1


### PR DESCRIPTION
Add the `devices` block to the `esphome:` section and replace `${deviceN}` name prefixes with `device_id` assignments. Entities are now grouped under their respective inverter device without redundant prefixes in the entity names.

Internal sensors (`powermeter0`/`powermeter1`) are left unchanged since they are not published.