### PR TITLE
Fix powermeter examples: migrate to capture_response, add state_class and status guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -506,6 +506,9 @@ jobs:
           . venv/bin/activate
           echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/esp32c6-compatibility-test.yaml
+          for YAML in tests/esp8266-powermeter-*.yaml; do
+            esphome -s external_components_source ../components compile $YAML
+          done
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 

--- a/powermeter-sensor-examples/esphome-http-rest-api.yaml
+++ b/powermeter-sensor-examples/esphome-http-rest-api.yaml
@@ -13,6 +13,7 @@ sensor:
     name: "Instantaneous Power"
     unit_of_measurement: W
     device_class: "power"
+    state_class: measurement
     accuracy_decimals: 2
     update_interval: never
 
@@ -21,14 +22,20 @@ interval:
     then:
       - http_request.get:
           url: ${esphome_rest_api_sensor_url}
+          capture_response: true
+          max_response_buffer_size: 2048
           request_headers:
             Content-Type: application/json
           on_response:
             then:
               - lambda: |-
-                  std::string response_data = id(http_request0).get_string();
-                  if(!response_data.empty()) {
-                    json::parse_json(response_data, [](JsonObject root) {
-                      id(powermeter0).publish_state(root["value"]);
+                  if (response->status_code == 200 && !body.empty()) {
+                    json::parse_json(body, [](JsonObject root) -> bool {
+                      auto value = root["value"];
+                      if (!value.isNull()) {
+                        id(powermeter0).publish_state(value.as<float>());
+                        return true;
+                      }
+                      return false;
                     });
                   }

--- a/powermeter-sensor-examples/mqtt-topic.yaml
+++ b/powermeter-sensor-examples/mqtt-topic.yaml
@@ -12,5 +12,6 @@ sensor:
     accuracy_decimals: 2
     unit_of_measurement: W
     device_class: power
+    state_class: measurement
     filters:
       - throttle_average: 15s

--- a/powermeter-sensor-examples/shelly-3em-http-status-json.yaml
+++ b/powermeter-sensor-examples/shelly-3em-http-status-json.yaml
@@ -13,6 +13,7 @@ sensor:
     name: "Instantaneous Power"
     unit_of_measurement: W
     device_class: "power"
+    state_class: measurement
     accuracy_decimals: 2
     update_interval: never
 
@@ -28,7 +29,13 @@ interval:
           on_response:
             then:
               - lambda: |-
-                  json::parse_json(body, [](JsonObject root) -> bool {
-                    id(powermeter0).publish_state(root["total_power"]);
-                    return true;
-                  });
+                  if (response->status_code == 200 && !body.empty()) {
+                    json::parse_json(body, [](JsonObject root) -> bool {
+                      auto value = root["total_power"];
+                      if (!value.isNull()) {
+                        id(powermeter0).publish_state(value.as<float>());
+                        return true;
+                      }
+                      return false;
+                    });
+                  }

--- a/powermeter-sensor-examples/tasmota-http-status-sns-en.yaml
+++ b/powermeter-sensor-examples/tasmota-http-status-sns-en.yaml
@@ -15,6 +15,7 @@ sensor:
     name: "Instantaneous Power"
     unit_of_measurement: W
     device_class: "power"
+    state_class: measurement
     accuracy_decimals: 2
     update_interval: never
 
@@ -23,14 +24,20 @@ interval:
     then:
       - http_request.get:
           url: ${tasmota_status_url}
+          capture_response: true
+          max_response_buffer_size: 2048
           request_headers:
             Content-Type: application/json
           on_response:
             then:
               - lambda: |-
-                  std::string response_data = id(http_request0).get_string();
-                  if(!response_data.empty()) {
-                    json::parse_json(response_data, [](JsonObject root) {
-                      id(powermeter0).publish_state(root["StatusSNS"]["SML"]["curr_w"]);
+                  if (response->status_code == 200 && !body.empty()) {
+                    json::parse_json(body, [](JsonObject root) -> bool {
+                      auto value = root["StatusSNS"]["SML"]["curr_w"];
+                      if (!value.isNull()) {
+                        id(powermeter0).publish_state(value.as<float>());
+                        return true;
+                      }
+                      return false;
                     });
                   }

--- a/powermeter-sensor-examples/tasmota-http-status-sns.yaml
+++ b/powermeter-sensor-examples/tasmota-http-status-sns.yaml
@@ -15,6 +15,7 @@ sensor:
     name: "Instantaneous Power"
     unit_of_measurement: W
     device_class: "power"
+    state_class: measurement
     accuracy_decimals: 2
     update_interval: never
 
@@ -23,14 +24,20 @@ interval:
     then:
       - http_request.get:
           url: ${tasmota_status_url}
+          capture_response: true
+          max_response_buffer_size: 2048
           request_headers:
             Content-Type: application/json
           on_response:
             then:
               - lambda: |-
-                  std::string response_data = id(http_request0).get_string();
-                  if(!response_data.empty()) {
-                    json::parse_json(response_data, [](JsonObject root) {
-                      id(powermeter0).publish_state(root["StatusSNS"]["SML"]["Leistung"]);
+                  if (response->status_code == 200 && !body.empty()) {
+                    json::parse_json(body, [](JsonObject root) -> bool {
+                      auto value = root["StatusSNS"]["SML"]["Leistung"];
+                      if (!value.isNull()) {
+                        id(powermeter0).publish_state(value.as<float>());
+                        return true;
+                      }
+                      return false;
                     });
                   }


### PR DESCRIPTION
## Summary

- Replace deprecated `id(http_request0).get_string()` with `capture_response: true` + `body` variable in `on_response` lambdas (ESPHome broke this API, see #276)
- Add `if (response->status_code == 200 && !body.empty())` guard to all HTTP examples to avoid log noise on failed requests
- Add `state_class: measurement` to all applicable powermeter sensors for correct Home Assistant energy dashboard integration (see #267)
- Extend CI to compile all `esp8266-powermeter-*.yaml` test configurations — previously they were only schema-validated, never compiled, which is why the `get_string()` breakage went undetected

## Test plan

- [ ] CI passes the new "Compile test configurations" loop over `esp8266-powermeter-*.yaml`
- [ ] Verify `tasmota-http-status-sns.yaml` and `-en` variant compile cleanly
- [ ] Verify `esphome-http-rest-api.yaml` compiles cleanly
- [ ] Verify `shelly-3em-http-status-json.yaml` compiles cleanly