### PR TITLE
Skip settings request (0x5503) for SOYOSOURCE_DISPLAY_AND_WIFI_VERSION

### DIFF
--- a/components/soyosource_display/soyosource_display.cpp
+++ b/components/soyosource_display/soyosource_display.cpp
@@ -179,7 +179,8 @@ void SoyosourceDisplay::on_soyosource_display_data_(const uint8_t &function, con
     switch (function) {
       case STATUS_COMMAND:
         this->on_soyosource_status_data_(data);
-        this->send_command(SETTINGS_COMMAND);
+        if (this->protocol_version_ != SOYOSOURCE_DISPLAY_AND_WIFI_VERSION)
+          this->send_command(SETTINGS_COMMAND);
         return;
       case SETTINGS_COMMAND:
         this->on_soyosource_settings_data_(data);

--- a/components/soyosource_display/soyosource_display.h
+++ b/components/soyosource_display/soyosource_display.h
@@ -88,7 +88,7 @@ class SoyosourceDisplay : public uart::UARTDevice, public PollingComponent {
 
   SoyosourceSettingsFrameT get_current_settings() { return current_settings_; }
   void register_select_listener(uint8_t holding_register, const std::function<void(uint8_t)> &func);
-  void send_command(uint8_t function);
+  virtual void send_command(uint8_t function);
   void display_version_send_command(uint8_t function, uint8_t value1, uint8_t value2, uint8_t value3);
   void update_setting(uint8_t holding_register, float value);
   void loop() override;

--- a/tests/components/soyosource_display/common.h
+++ b/tests/components/soyosource_display/common.h
@@ -22,11 +22,21 @@ class TestableNumber : public number::Number {
 
 class TestableSoyosourceDisplay : public SoyosourceDisplay {
  public:
+  int send_command_calls{0};
+  uint8_t last_send_command_arg{0};
+
   void update() override {}
+  void send_command(uint8_t function) override {
+    send_command_calls++;
+    last_send_command_arg = function;
+  }
 
   // Direct handler accessors bypass send_command() (which would crash with null UART parent).
   void on_soyo_status(const std::vector<uint8_t> &data) { this->on_soyosource_status_data_(data); }
   void on_soyo_settings(const std::vector<uint8_t> &data) { this->on_soyosource_settings_data_(data); }
+  void on_soyo_display_data(uint8_t function, const std::vector<uint8_t> &data) {
+    this->on_soyosource_display_data_(function, data);
+  }
   void on_ms51_status(const std::vector<uint8_t> &data) { this->on_ms51_status_data_(data); }
   void on_ms51_settings(const std::vector<uint8_t> &data) { this->on_ms51_settings_data_(data); }
   void on_ms51_v2_settings(const std::vector<uint8_t> &data) { this->on_ms51_v2_settings_data_(data); }

--- a/tests/components/soyosource_display/soyosource_display_test.cpp
+++ b/tests/components/soyosource_display/soyosource_display_test.cpp
@@ -343,6 +343,24 @@ TEST(SoyoStatusDisplayAndWifiVersionTest, NullSensorsDoNotCrash) {
   d.on_soyo_status(SOYO_STATUS_DISPLAY_AND_WIFI_VERSION);
 }
 
+TEST(SoyoStatusDisplayAndWifiVersionTest, NoSettingsRequestSentAfterStatus) {
+  TestableSoyosourceDisplay d;
+  d.set_protocol(SOYOSOURCE_DISPLAY_AND_WIFI_VERSION);
+
+  d.on_soyo_display_data(0x01, SOYO_STATUS_DISPLAY_AND_WIFI_VERSION);
+
+  EXPECT_EQ(d.send_command_calls, 0);
+}
+
+TEST(SoyoStatusWifiVersionTest, SettingsRequestSentAfterStatus) {
+  TestableSoyosourceDisplay d;
+
+  d.on_soyo_display_data(0x01, SOYO_STATUS_WIFI_VERSION);
+
+  EXPECT_EQ(d.send_command_calls, 1);
+  EXPECT_EQ(d.last_send_command_arg, 0x03);  // SETTINGS_COMMAND
+}
+
 // ── MS51 status ───────────────────────────────────────────────────────────────
 
 TEST(Ms51StatusTest, StandbyWithNoLoad) {


### PR DESCRIPTION
## Summary

- On `SOYOSOURCE_DISPLAY_AND_WIFI_VERSION` the device does not respond to `55:03` with a settings frame — only a 4-byte stub (`XX:XX:16:20`) is returned, which the parser discards as an invalid header
- Settings are delivered periodically as a spontaneous `D3` response to the regular `55:01` status poll; that path was already handled correctly
- This change simply suppresses the unnecessary `55:03` follow-up after each status response to avoid generating noise on the bus

## Changes

- `soyosource_display.cpp`: skip `send_command(SETTINGS_COMMAND)` when `protocol_version_ == SOYOSOURCE_DISPLAY_AND_WIFI_VERSION`
- `soyosource_display.h`: make `send_command()` virtual (required for test override)
- `common.h`: add `send_command` call-tracking override and `on_soyo_display_data` dispatch helper
- `soyosource_display_test.cpp`: two new tests — no settings request for Display+WiFi version; settings request still sent for WiFi version (regression guard)

## Test plan

- [x] All 97 existing unit tests still pass
- [x] `SoyoStatusDisplayAndWifiVersionTest.NoSettingsRequestSentAfterStatus` — verifies `send_command` is not called after a status response
- [x] `SoyoStatusWifiVersionTest.SettingsRequestSentAfterStatus` — verifies `send_command(0x03)` is still called for the standard WiFi version